### PR TITLE
HPCC-JAPIs-61 Implement SFTP stop using WS to upload files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,15 @@ For more information on how to use Maven see http://maven.apache.org
 
 
 Projects contained within:
+- org.hpccsystems.ws.client          API which Standardize and facilitate interaction with HPCC Web based Services.
+                                     *The project is based on stub code generated from WSDLs using Eclipse tools based on Apache Axis
+                                     *and JSch(Java Secure Channel) for secure ftp transfers
+
 - org.hpccsystems.clienttools        Java based interface to HPCC client tools 
                                      *Currently only interfaces with eclcc
 
 - org.hpccsystems.rdf.rdf2hpcc       RDF data ingestion tool to HPCC 
                                      *Based on Apache Jena and dependent on org.hpccsystems.ws.client
-
-- org.hpccsystems.ws.client          API which Standardize and facilitate interaction with HPCC Web based Services.
-                                     *The project is based on stub code generated from WSDLs using Eclipse tools based on Apache Axis.
-
-- org.hpccsystems.ws.client.legacy   API which Standardize and facilitate interaction with legacy HPCC Web based Services
-                                     *Dependent on org.hpccsystems.ws.client
 
 ** PLEASE NOTE **
 

--- a/org.hpccsystems.ws.client/pom.xml
+++ b/org.hpccsystems.ws.client/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.hpccsystems.hpccjapi</groupId>
   <artifactId>wsclient</artifactId>
   <packaging>jar</packaging>
-  <version>0.3-SNAPSHOT</version>
+  <version>0.4-SNAPSHOT</version>
   <name>HPCC Web Services Client API</name>
 
   <properties>
@@ -53,6 +53,11 @@
       <artifactId>junit</artifactId>
       <version>4.11</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>com.jcraft</groupId>
+        <artifactId>jsch</artifactId>
+        <version>0.1.51</version>
     </dependency>
   </dependencies>
 

--- a/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/HPCCWsClient.java
+++ b/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/HPCCWsClient.java
@@ -680,18 +680,13 @@ public class HPCCWsClient extends DataSingleton
         return success;
     }
 
-    /**
-     * Uploads a file to the first dropzone found on the target HPCC System
-     * @param file   - The file
-     * @return       - Succcess
-     */
-    public boolean uploadFileToHPCC(File file)
+    public boolean uploadFileToHPCC(String localFileName, String targetFilename, String machineLoginUser, String password)
     {
         try
         {
             HPCCFileSprayClient fileSprayClient = getFileSprayClient();
             if (fileSprayClient != null)
-                fileSprayClient.uploadFileLocalDropZone(file);
+                fileSprayClient.sftpPutFileOnTargetLandingZone(localFileName, targetFilename, machineLoginUser, password);
             else
                 throw new Exception("Could not initialize HPCC File Spray Client");
         }
@@ -702,55 +697,6 @@ public class HPCCWsClient extends DataSingleton
         }
 
         return true;
-    }
-
-    /**
-     * Creates a file on HPCC landingzone, and appends data to file.
-     * @param fileName                - The target file name.
-     * @param targetDropzoneAddress   - can be null, if null will attempt to fetch the first dropzone from the local HPCC System
-     * @param data                    - the data
-     * @return
-     * @throws Exception              - caller must handle exceptions
-     */
-    public boolean writeToHPCCFile(String fileName, String targetDropzoneAddress, String data) throws Exception
-    {
-        boolean success = false;
-
-        HPCCWsFileIOClient wsFileIOClient = getWsFileIOClient();
-        HPCCFileSprayClient fileSprayClient = getFileSprayClient();
-
-        if (fileSprayClient != null)
-        {
-            if (targetDropzoneAddress == null || targetDropzoneAddress.length() == 0)
-            {
-                DropZone[] localdropzones = fileSprayClient.fetchLocalDropZones();
-                if (localdropzones != null && localdropzones.length > 0)
-                {
-                    targetDropzoneAddress = localdropzones[0].getNetAddress();
-                }
-            }
-        }
-        else
-            throw new Exception("Could not initialize HPCC FileSpray Client");
-
-        if (wsFileIOClient != null)
-        {
-            if (targetDropzoneAddress != null && targetDropzoneAddress.length() == 0)
-            {
-                if (!wsFileIOClient.createHPCCFile(fileName, targetDropzoneAddress, true))
-                        throw new Exception("Could not create target HPCC namespaces file.");
-
-                    //Remote HPCC file has been created, encode the data so it can be uploaded as binary data.
-                    //byte [] encodedBytes = encodeData(triplesCSVFormat.toString());
-                    //The data was being encoded, but latest test don't seem to require encoding.
-                    success = wsFileIOClient.writeHPCCFileData(data.getBytes(), fileName, targetDropzoneNetAddres, false, 0, 0);
-            }
-        }
-        else
-            throw new Exception("Could not initialize HPCC FileIO Client");
-
-        Utils.println(System.out, "Success: " + String.valueOf(success), false,verbosemode);
-        return success;
     }
 
     /**

--- a/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/utils/Sftp.java
+++ b/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/utils/Sftp.java
@@ -1,0 +1,100 @@
+package org.hpccsystems.ws.client.utils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Properties;
+import java.util.Vector;
+
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+
+public class Sftp
+{
+    static public void lzPut(String localFileName, String hostname, String landingZonePath, String targetFileName, String machineLoginUsername, String password, boolean isLZLinux, Properties connconfig) throws Exception
+    {
+        {
+            char lzSep;
+            if (isLZLinux)
+                lzSep = Utils.LINUX_SEP;
+            else
+                lzSep = Utils.WIN_SEP;
+
+            if (hostname == null || hostname.length() == 0)
+                throw new Exception("Target HPCC landingzone hostname is required");
+            if (landingZonePath == null || landingZonePath.length()==0)
+                throw new Exception("Target HPCC landing zone path is required");
+            if (localFileName == null || localFileName.length()==0)
+                throw new Exception ("Fully qualified local file path is required");
+
+            File fileToUpload = new File(localFileName);
+            if (!fileToUpload.isFile())
+                throw new Exception ("Target file name does not appear to be a file: " + localFileName);
+
+            if (targetFileName == null || targetFileName.length()==0)
+                targetFileName = fileToUpload.getName();
+
+            if (connconfig == null)
+                connconfig = new java.util.Properties();
+
+            if (!connconfig.containsKey("StrictHostKeyChecking"))
+                connconfig.put("StrictHostKeyChecking", "no");
+
+            Session session = null;
+            Channel channel = null;
+            try
+            {
+                JSch ssh = new JSch();
+                session = ssh.getSession(machineLoginUsername, hostname, 22);
+                session.setConfig(connconfig);
+                session.setPassword(password);
+                session.connect();
+
+                channel = session.openChannel("sftp");
+                channel.connect();
+
+                ChannelSftp sftp = (ChannelSftp) channel;
+                Vector<ChannelSftp.LsEntry> files;
+                try
+                {
+                    files = (Vector<ChannelSftp.LsEntry>)sftp.ls(landingZonePath);
+                    if (files == null || files.size() == 0)
+                        throw new Exception();
+                    else
+                        System.out.print("Found landing zone " + landingZonePath + " with " + files.size() + " files\n");
+                }
+                catch (Exception e)
+                {
+                    e.printStackTrace();
+                    System.out.println("Could not contact Target landingzone");
+                    return;
+                }
+
+                try
+                {
+                    System.out.println("Attempting to sftp " + localFileName + " to " + hostname + ":" + landingZonePath + lzSep +  targetFileName);
+                    sftp.put(new FileInputStream(fileToUpload), landingZonePath + lzSep + targetFileName );
+                    System.out.println("Finished Attempt to sftp " + localFileName + " to " + hostname + ":" + landingZonePath + lzSep +  targetFileName + " please verify");
+                }
+                catch (Exception e)
+                {
+                    System.out.println("Could not sftp " + localFileName + " to " + hostname + ":" + landingZonePath + lzSep +  targetFileName);
+                    System.out.println(e.getLocalizedMessage());
+                }
+            }
+            catch (Exception e)
+            {
+                System.out.println("Unexpected problem while attempting to perform LandingZone file transfer");
+                System.out.println(e.getLocalizedMessage());
+            }
+            finally
+            {
+                if (channel != null)
+                    channel.disconnect();
+                if (session != null)
+                    session.disconnect();
+            }
+        }
+    }
+}

--- a/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/utils/Utils.java
+++ b/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/utils/Utils.java
@@ -33,6 +33,9 @@ import org.xml.sax.SAXException;
 
 public class Utils
 {
+    final static char LINUX_SEP =  '/';
+    final static char WIN_SEP =  '\\';
+
     /**
      * @param wsdlurl - url to web service definition
      * @return        - version reported as ver_ parameter in url

--- a/org.hpccsystems.ws.client/src/test/java/org/hpccsystems/ws/client/platform/test/PlatformTester.java
+++ b/org.hpccsystems.ws.client/src/test/java/org/hpccsystems/ws/client/platform/test/PlatformTester.java
@@ -1,11 +1,10 @@
 package org.hpccsystems.ws.client.platform.test;
 
-import java.io.File;
-import java.lang.annotation.Annotation;
 import java.util.List;
 
 import org.hpccsystems.ws.client.HPCCWsClient;
 import org.hpccsystems.ws.client.HPCCWsDFUClient;
+import org.hpccsystems.ws.client.extended.HPCCWsAttributesClient;
 import org.hpccsystems.ws.client.gen.wsdfu.v1_29.DFUDataColumn;
 import org.hpccsystems.ws.client.gen.wsworkunits.v1_46.WUPublishWorkunitResponse;
 import org.hpccsystems.ws.client.platform.Platform;
@@ -29,6 +28,7 @@ public class PlatformTester
             HPCCWsClient connector = platform.getHPCCWSClient();
             connector.setVerbosemode(true);
 
+            int pport = HPCCWsAttributesClient.getOriginalPort();
             System.out.println("wsdfu ver: " + connector.getwsDFUClientClientVer());
             HPCCWsDFUClient wsDFUClient = connector.getWsDFUClient();
 
@@ -41,7 +41,9 @@ public class PlatformTester
             System.out.println("wsfileio ver: " + connector.getWsFileIOClientVer());
             System.out.println("wssmc ver: " + connector.getWsSMCClientClientVer());
             //connector.uploadFileToHPCC(new File("C://assignments//data//shortpersons"));
-            connector.uploadFileToHPCC(new File("C://assignments//data//shortaccounts"));
+            //connector.uploadFileToHPCC(new File("C://assignments//data//shortaccounts"));
+            //connector.uploadFileToHPCC(new File("C://assignments//data//small.txt"));
+            connector.uploadFileToHPCC("C://assignments//data//shortpersons", "myhpcctargetname", "hadoop", "hadoop");
 
             //for our curiosity, what cluster groups and clusters are available.
             List<String> clusters = connector.getAvailableTargetClusterNames();


### PR DESCRIPTION
- Add JSCH dependancy
- Add SFTP utility class
- Implement SFTP to HPCC Landing Zone method
- Add new helper methods in filespray which utilze sftp to upload files
- Add new helper method in wsclient to make use of filespray methods
- Updated README

Signed-off-by: rpastrana <rodrigo.pastrana@lexisnexis.com>