### PR TITLE
Support retrieving results, etc. from archived workunits

### DIFF
--- a/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClient.java
+++ b/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClient.java
@@ -529,7 +529,7 @@ public class HPCCWsWorkUnitsClient extends DataSingleton
             		return getWUInfo(wuid);
             	}
                 workunit = new WorkunitInfo(wuInfoResponse.getWorkunit());
-                workunit.setEspUrl(this.getSoapProxy().getEndpoint().replace("WsWorkunits", ""));
+                workunit.setOriginalEclWatchUrl(getEclWatchUrl());
                 
             }
             else
@@ -722,7 +722,7 @@ public class HPCCWsWorkUnitsClient extends DataSingleton
                 createdWU.setCluster(wu.getCluster());
                 createdWU.setJobname(wu.getJobname());
                 createdWU.setSleepMillis(wu.getSleepMillis());
-                createdWU.setEspUrl(this.getSoapProxy().getEndpoint().replace("WsWorkunits", ""));
+                createdWU.setOriginalEclWatchUrl(getEclWatchUrl());
                 
             }
             else
@@ -804,7 +804,7 @@ public class HPCCWsWorkUnitsClient extends DataSingleton
             for (int i = 0; i < ecls.length; i++)
             {
             	WorkunitInfo w=new WorkunitInfo(ecls[i]);
-            	w.setEspUrl(this.getSoapProxy().getEndpoint().replace("WsWorkunits", ""));
+            	w.setOriginalEclWatchUrl(getEclWatchUrl());
                 wks.add(w);
             }
         }
@@ -1343,5 +1343,10 @@ public class HPCCWsWorkUnitsClient extends DataSingleton
         	throw new Exception("Unable to restore workunit " + wuid);
 		}
         return true;
+    }
+    
+    private String getEclWatchUrl() throws Exception {
+        String url=this.getSoapProxy().getEndpoint().toLowerCase().replace("wsworkunits", "");
+        return url;
     }
 }

--- a/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClient.java
+++ b/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClient.java
@@ -529,6 +529,8 @@ public class HPCCWsWorkUnitsClient extends DataSingleton
             		return getWUInfo(wuid);
             	}
                 workunit = new WorkunitInfo(wuInfoResponse.getWorkunit());
+                workunit.setEspUrl(this.getSoapProxy().getEndpoint().replace("WsWorkunits", ""));
+                
             }
             else
             {
@@ -720,6 +722,8 @@ public class HPCCWsWorkUnitsClient extends DataSingleton
                 createdWU.setCluster(wu.getCluster());
                 createdWU.setJobname(wu.getJobname());
                 createdWU.setSleepMillis(wu.getSleepMillis());
+                createdWU.setEspUrl(this.getSoapProxy().getEndpoint().replace("WsWorkunits", ""));
+                
             }
             else
             {

--- a/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/platform/WorkunitInfo.java
+++ b/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/platform/WorkunitInfo.java
@@ -11,6 +11,7 @@ public class WorkunitInfo extends org.hpccsystems.ws.client.gen.wsworkunits.v1_4
     private int               maxMonitorTime   = HPCCWsWorkUnitsClient.defaultMaxWaitTime;
     private int               sleepMillis      = HPCCWsWorkUnitsClient.defaultWaitTime;
     private NamedValue[]      namedValues      = null;
+    private String espUrl=null;
 
     /**
      * Create an ECL workunit from a axis-generated soap class ECL Workunit
@@ -158,6 +159,7 @@ public class WorkunitInfo extends org.hpccsystems.ws.client.gen.wsworkunits.v1_4
         this.setDebugValues(base.getDebugValues());
         this.setApplicationValues(base.getApplicationValues());
         this.setAllowedClusters(base.getAllowedClusters());
+        this.setArchived(base.getArchived());
     }
 
     public boolean update(org.hpccsystems.ws.client.gen.wsworkunits.v1_46.ECLWorkunit wu)
@@ -251,4 +253,13 @@ public class WorkunitInfo extends org.hpccsystems.ws.client.gen.wsworkunits.v1_4
         }
         return this.getQuery().getText();
     }
+
+	public String getEspUrl() {
+		return espUrl;
+	}
+
+	public void setEspUrl(String serverhost) {
+		this.espUrl=serverhost;
+	}
+    
 }

--- a/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/platform/WorkunitInfo.java
+++ b/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/platform/WorkunitInfo.java
@@ -11,7 +11,7 @@ public class WorkunitInfo extends org.hpccsystems.ws.client.gen.wsworkunits.v1_4
     private int               maxMonitorTime   = HPCCWsWorkUnitsClient.defaultMaxWaitTime;
     private int               sleepMillis      = HPCCWsWorkUnitsClient.defaultWaitTime;
     private NamedValue[]      namedValues      = null;
-    private String espUrl=null;
+    private String originalEclWatchUrl=null;
 
     /**
      * Create an ECL workunit from a axis-generated soap class ECL Workunit
@@ -254,12 +254,12 @@ public class WorkunitInfo extends org.hpccsystems.ws.client.gen.wsworkunits.v1_4
         return this.getQuery().getText();
     }
 
-	public String getEspUrl() {
-		return espUrl;
+	public String getOriginalEclWatchUrl() {
+		return originalEclWatchUrl;
 	}
 
-	public void setEspUrl(String serverhost) {
-		this.espUrl=serverhost;
+	public void setOriginalEclWatchUrl(String serverhost) {
+		this.originalEclWatchUrl=serverhost;
 	}
     
 }


### PR DESCRIPTION
add check in getWUInfo to un-archive a workunit if it's archived before returning

add getWUResults to retrieve a workunit result

add espURL for external reference to track where a WorkunitInfo came from. (Rodrigo, there may be a better place to get this from than parsing the soap endpoint string, let me know.)

