### PR TITLE
JAPI-10 ESP uses "csv" as an alias for ASCII encoding

### DIFF
--- a/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/HPCCFileSprayClient.java
+++ b/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/HPCCFileSprayClient.java
@@ -422,6 +422,27 @@ public class HPCCFileSprayClient extends DataSingleton
 
         return getDfuProgress(resp.getWuid());
     }
+    
+    /**
+     * Spray XML data file from the first local dropzone onto given cluster group.
+     * defaults to first local dropzone, row tag to "tag", source format to "ASCII"
+     * and max len to 8192
+     *
+     * @param sourceFileName
+     * @param targetFileName
+     * @param prefix
+     * @param destGroup
+     * @param overwrite
+     * @return ProgressResponse
+     * @throws Exception
+     */
+    public ProgressResponse sprayLocalXML(String sourceFileName, String targetFileName, String prefix, String destGroup, boolean overwrite) throws Exception
+    {
+        if (localDropZones == null)
+            localDropZones = fetchLocalDropZones();
+
+        return sprayXML(localDropZones[0], sourceFileName, targetFileName, prefix, destGroup, "tag", overwrite, FileFormat.DFUff_ascii, 8192);
+    }
 
     /**
      * Spray XML data file from the first local dropzone onto given cluster group.
@@ -437,7 +458,7 @@ public class HPCCFileSprayClient extends DataSingleton
      * @return ProgressResponse
      * @throws Exception
      */
-    public ProgressResponse sprayLocalXML(String sourceFileName, String targetFileName, String prefix, String destGroup, boolean overwrite,FileFormat format, String rowtag, Integer maxrecsize) throws Exception
+    public ProgressResponse sprayLocalXML(String sourceFileName, String targetFileName, String prefix, String destGroup, boolean overwrite, FileFormat format, String rowtag, Integer maxrecsize) throws Exception
     {
         if (localDropZones == null)
             localDropZones = fetchLocalDropZones();

--- a/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/utils/FileFormat.java
+++ b/org.hpccsystems.ws.client/src/main/java/org/hpccsystems/ws/client/utils/FileFormat.java
@@ -6,6 +6,7 @@ public enum FileFormat
 {
     DFUff_fixed(0),
     DFUff_csv(1),
+    DFUff_ascii(1),
     DFUff_utf8(2),
     DFUff_utf8n(3),
     DFUff_utf16(4),
@@ -27,7 +28,7 @@ public enum FileFormat
     static
     {
         mapDFUFileFormatNameCode.put("csv",                FileFormat.DFUff_csv);
-        mapDFUFileFormatNameCode.put("ascii",              FileFormat.DFUff_csv);
+        mapDFUFileFormatNameCode.put("ascii",              FileFormat.DFUff_ascii);
         mapDFUFileFormatNameCode.put("utf8",               FileFormat.DFUff_utf8);
         mapDFUFileFormatNameCode.put("utf16",              FileFormat.DFUff_utf16);
         mapDFUFileFormatNameCode.put("utf16le",            FileFormat.DFUff_utf16le);


### PR DESCRIPTION
Since ESP aliases the CSV data format flag for ASCII, the client should do the same to prevent further confusion.

Also, add new method with default values for formattype=ASCII, maxsize= 8192 and rowtag = "tag"
Signed-off-by: rpastrana <rodrigo.pastrana@lexisnexis.com>