### PR TITLE
Refactoring changes to support returning child dataset info from HPCCWsDFUClient.getDatasetFields

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsDFUClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsDFUClient.java
@@ -33,6 +33,8 @@ import org.hpccsystems.ws.client.gen.wsdfu.v1_29.EspException;
 import org.hpccsystems.ws.client.gen.wsdfu.v1_29.WsDfuLocator;
 import org.hpccsystems.ws.client.gen.wsdfu.v1_29.WsDfuServiceSoap;
 import org.hpccsystems.ws.client.gen.wsdfu.v1_29.WsDfuServiceSoapProxy;
+import org.hpccsystems.ws.client.platform.DFUDataColumnInfo;
+import org.hpccsystems.ws.client.platform.DFUFileDetailInfo;
 import org.hpccsystems.ws.client.platform.DataSingleton;
 import org.hpccsystems.ws.client.utils.Connection;
 import org.hpccsystems.ws.client.utils.EqualsUtil;
@@ -137,7 +139,6 @@ public class HPCCWsDFUClient extends DataSingleton
                             + espexception.getMessage(), false, true);
                 }
             }
-            e.printStackTrace();
             throw e;
         }
 
@@ -166,7 +167,7 @@ public class HPCCWsDFUClient extends DataSingleton
         }
         if (beginrow == null)
         {
-            beginrow = (long) 1;
+            beginrow = (long) 0;
         }
         if (numrows == null)
         {
@@ -203,7 +204,6 @@ public class HPCCWsDFUClient extends DataSingleton
             }
             catch (Exception e)
             {
-                e.printStackTrace();
                 return null;
             }
             return null;
@@ -218,7 +218,6 @@ public class HPCCWsDFUClient extends DataSingleton
                             + espexception.getMessage(), false, true);
                 }
             }
-            e.printStackTrace();
             throw e;
         }
     }
@@ -285,7 +284,6 @@ public class HPCCWsDFUClient extends DataSingleton
                             + espexception.getMessage(), false, true);
                 }
             }
-            e.printStackTrace();
             throw e;
         }
 
@@ -355,7 +353,6 @@ public class HPCCWsDFUClient extends DataSingleton
                             + espexception.getMessage(), false, true);
                 }
             }
-            e.printStackTrace();
             throw e;
         }
         return cols;
@@ -448,118 +445,15 @@ public class HPCCWsDFUClient extends DataSingleton
      * @return an ArrayList of DFUDataColumns containing the name and field type.
      * @throws Exception
      */
-    public ArrayList<DFUDataColumn> getDatasetFields(String datasetname, String clusterName, String fieldSeparator)
+    public ArrayList<DFUDataColumnInfo> getDatasetFields(String datasetname, String clusterName, String fieldSeparator)
             throws Exception
     {
-        String filetype = "";
-        DFUInfoResponse resp = null;
-        try
-        {
-            resp = getFileInfo(datasetname, null);
-            // thor files store filetype in content type
-            filetype = resp.getFileDetail().getContentType();
-            if (filetype == null || filetype.equals(""))
-            {
-                // some csvs in OSS HPCC Store filetype in format
-                filetype = resp.getFileDetail().getFormat();
-
-                // csvs loaded as ascii get a format of "csv", csvs loaded as
-                // utf-8 get a format of "utf8"
-                if (filetype.toLowerCase().startsWith("utf"))
-                {
-                    filetype = "CSV";
-                }
-                if (filetype == null || filetype.equals(""))
-                {
-                    // some HPCC-generated xml files use neither, check ecl
-                    // record for xpath
-                    if (resp.getFileDetail().getEcl() != null
-                            && resp.getFileDetail().getEcl().toLowerCase().contains("xpath"))
-                    {
-                        filetype = "XML";
-                        // in some cases THOR files have nothing in format or
-                        // filetype, but if the file doesn't have any
-                        // identifying info but does have a record definition,
-                        // assume it's a THOR file
-                    }
-                    else if (resp.getFileDetail().getEcl() != null)
-                    {
-                        filetype = "THOR";
-                    }
-                    else
-                    {
-                        throw new Exception("Unknown file format for logical file " + datasetname);
-                    }
-                }
-            }
-        }
-        catch (Exception e)
-        {
-            throw e;
-        }
-        ArrayList<DFUDataColumn> fields = new ArrayList<DFUDataColumn>();
-        if (filetype.equalsIgnoreCase("THOR") || filetype.equalsIgnoreCase("FLAT"))
-        {
-            // bug in DFUGetDataColumns: Decimal datatypes being returned as real. Until it's fixed,
-            // need to retrieve fields from ECL.
-            // fields = getFileDataColumns(datasetname, null);
-            String ecl = resp.getFileDetail().getEcl();
-            fields = getRecordFromECL(ecl);
-        }
-        else if (filetype.equalsIgnoreCase("CSV"))
-        {
-            // CSVs created by HPCC have file data; sprayed csvs return only
-            // "line" from this call, and have their fields defined
-            // in the record definition in the ecl attribute of dfu file info
-            try
-            {
-                fields = getFileDataColumns(datasetname, null);
-                if (fields.size() == 2 && fields.get(0).getColumnLabel().equals("line"))
-                {
-                    fields = new ArrayList<DFUDataColumn>();
-                }
-                if (fields != null && fields.size() > 0)
-                {
-                    return fields;
-                }
-            }
-            catch (Exception e)
-            {}
-            if (fieldSeparator == null)
-            {
-                fieldSeparator = resp.getFileDetail().getCsvSeparate();
-            }
-            String ecl = resp.getFileDetail().getEcl();
-            if (ecl == null || ecl.equals(""))
-            {
-                String firstrow = getFirstRow(datasetname, clusterName);
-                if (firstrow != null)
-                {
-                    String[] flds = firstrow.split(fieldSeparator);
-                    for (int i = 0; i < flds.length; i++)
-                    {
-                        DFUDataColumn du = new DFUDataColumn();
-                        du.setColumnLabel("Field" + String.valueOf(i + 1));
-                        du.setColumnType("STRING");
-                        fields.add(du);
-                    }
-                }
-            }
-            else
-            {
-                fields = this.getRecordFromECL(ecl);
-            }
-        }
-        else if (filetype.equalsIgnoreCase("XML"))
-        {
-            String ecl = resp.getFileDetail().getEcl();
-            if (ecl != null && !ecl.equals(""))
-            {
-                fields = this.getRecordFromECL(ecl);
-            }
-        }
-        return fields;
-    }
+    	DFUFileDetailInfo info=getFileDetails(datasetname,clusterName);
+    	if (fieldSeparator != null) {
+    		info.setCsvSeparate(fieldSeparator);
+    	}
+    	return info.deduceFields();
+     }
 
     /**
      * Returns the first row of data for a dataset
@@ -573,65 +467,18 @@ public class HPCCWsDFUClient extends DataSingleton
      */
     public String getFirstRow(String datasetname, String clustername) throws Exception
     {
-        NodeList rowdata = getFileData(datasetname, (long) 1, 1, clustername);
+        NodeList rowdata = getFileData(datasetname, (long) 0, 1, clustername);
         if (rowdata != null && rowdata.getLength() > 0)
         {
-            String firstrow = rowdata.item(0).getTextContent();
-            if (firstrow != null)
-            {
-                return firstrow;
-            }
+        	if (rowdata.item(0).hasChildNodes()) 
+        	{
+        		return rowdata.item(0).getFirstChild().getTextContent();
+        	} 
+        	else {
+        		return rowdata.item(0).getTextContent();
+        	}
         }
         return null;
-    }
-
-    /**
-     * @param eclRecordDefinition
-     *            - a RECORD definition, either in RECORD\nSTRING1\nEND; format, or in {STRING1 field} inline format,.
-     *            currently handles XPATH recordsets but doesn't save XPATH info. A few issues with child dataset
-     *            records
-     * @return An ArrayList of DFUDataColumns
-     * @throws Exception
-     */
-    private ArrayList<DFUDataColumn> getRecordFromECL(String eclRecordDefinition) throws Exception
-    {
-        ArrayList<DFUDataColumn> cols = new ArrayList<DFUDataColumn>();
-        eclRecordDefinition = eclRecordDefinition.replaceAll("(;|,|RECORD|\\{|\\})", "\n");
-        eclRecordDefinition = eclRecordDefinition.replaceAll("RECORD", "RECORD\n");
-        eclRecordDefinition = eclRecordDefinition.replaceAll("\n\n", "\n");
-        String[] lines = eclRecordDefinition.split("\n");
-        for (int i = 0; i < lines.length; i++)
-        {
-            String thisline = lines[i].trim();
-            if (thisline.equals(""))
-            {
-                continue;
-            }
-            if (thisline.matches("(RECORD|END|\\{|\\})"))
-            {
-                continue;
-            }
-            // TODO: handle xml field definitions
-            if (thisline.toLowerCase().contains("xpath"))
-            {
-                continue;
-            }
-            String[] fieldargs = thisline.split(" ");
-            if (fieldargs.length < 2)
-            {
-                throw new Exception("Invalid record field definition " + thisline);
-            }
-            if (!fieldargs[0].toUpperCase().matches(
-                    "(STRING|INTEGER|QSTRING|UTF|UNSIGNED|INTEGER|UNICODE|DATA|VARSTRING|VARUNICODE|DECIMAL|REAL|BOOLEAN).*"))
-            {
-                throw new Exception("Invalid record field type " + fieldargs[0]);
-            }
-            DFUDataColumn col = new DFUDataColumn();
-            col.setColumnType(fieldargs[0].toUpperCase());
-            col.setColumnLabel(fieldargs[1]);
-            cols.add(col);
-        }
-        return cols;
     }
 
     private void handleException(ArrayOfEspException exp) throws Exception
@@ -643,7 +490,7 @@ public class HPCCWsDFUClient extends DataSingleton
                 EspException ex = exp.getException()[i];
                 Utils.println(System.out, ex.getMessage(), true, verbose);
             }
-            throw new Exception(exp);
+            throw exp;
         }
     }
 
@@ -748,5 +595,52 @@ public class HPCCWsDFUClient extends DataSingleton
         result = HashCodeUtil.hash(result, ((Stub)  wsDfuServiceSoapProxy.getWsDfuServiceSoap()).getUsername());
         result = HashCodeUtil.hash(result, ((Stub)  wsDfuServiceSoapProxy.getWsDfuServiceSoap()).getPassword());
         return result;
+    }
+    
+   /**
+     * @param logicalname
+     *            - logical file to get file info for, can start with '~' or not
+     * @param clustername
+     *            - Optional. If specified, the cluster on which to search for the file
+     * @return a DFUInfoResponse object containing the file info
+     * @throws Exception
+     */
+    public DFUFileDetailInfo getFileDetails(String logicalname, String clustername) throws Exception
+    {
+        try
+        {
+            DFUInfoResponse resp = this.getFileInfo(logicalname, clustername);
+            if (resp == null)
+            {
+                throw new FileNotFoundException(logicalname + " does not exist");
+            }
+            this.handleException(resp.getExceptions());
+            DFUFileDetailInfo info=new DFUFileDetailInfo(resp.getFileDetail());
+            info.setFirstline(this.getFirstRow(logicalname, clustername));
+            if (info.getFilename() != null) {
+                try {
+                    info.setColumns(getFileMetaData(logicalname,clustername));
+                } catch (ArrayOfEspException e) {
+                    if (e.getException().length>0 && e.getException(0).getMessage() != null
+                            && e.getException(0).getMessage().contains("not available in service WsDfu")) {
+                        //for clusters on version < 5.0.2, this service doesn't exist; do it the old fashioned way
+                        info.setColumns(this.getFileDataColumns(logicalname,clustername));
+                    }
+                }
+            }  
+            return info;
+        }
+        catch (ArrayOfEspException e)
+        {
+            if (e != null)
+            {
+                for (EspException espexception : e.getException())
+                {
+                    Utils.println(System.out, "Error retrieving file type for file: " + espexception.getSource()
+                            + espexception.getMessage(), false, true);
+                }
+            }
+            throw e;
+         }
     }
 }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsDFUClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsDFUClient.java
@@ -448,12 +448,13 @@ public class HPCCWsDFUClient extends DataSingleton
     public ArrayList<DFUDataColumnInfo> getDatasetFields(String datasetname, String clusterName, String fieldSeparator)
             throws Exception
     {
-    	DFUFileDetailInfo info=getFileDetails(datasetname,clusterName);
-    	if (fieldSeparator != null) {
-    		info.setCsvSeparate(fieldSeparator);
-    	}
-    	return info.deduceFields();
-     }
+        DFUFileDetailInfo info = getFileDetails(datasetname, clusterName);
+        if (fieldSeparator != null)
+        {
+            info.setCsvSeparate(fieldSeparator);
+        }
+        return info.deduceFields();
+    }
 
     /**
      * Returns the first row of data for a dataset
@@ -597,7 +598,7 @@ public class HPCCWsDFUClient extends DataSingleton
         return result;
     }
     
-   /**
+    /**
      * @param logicalname
      *            - logical file to get file info for, can start with '~' or not
      * @param clustername
@@ -615,19 +616,24 @@ public class HPCCWsDFUClient extends DataSingleton
                 throw new FileNotFoundException(logicalname + " does not exist");
             }
             this.handleException(resp.getExceptions());
-            DFUFileDetailInfo info=new DFUFileDetailInfo(resp.getFileDetail());
+            DFUFileDetailInfo info = new DFUFileDetailInfo(resp.getFileDetail());
             info.setFirstline(this.getFirstRow(logicalname, clustername));
-            if (info.getFilename() != null) {
-                try {
-                    info.setColumns(getFileMetaData(logicalname,clustername));
-                } catch (ArrayOfEspException e) {
-                    if (e.getException().length>0 && e.getException(0).getMessage() != null
-                            && e.getException(0).getMessage().contains("not available in service WsDfu")) {
-                        //for clusters on version < 5.0.2, this service doesn't exist; do it the old fashioned way
-                        info.setColumns(this.getFileDataColumns(logicalname,clustername));
+            if (info.getFilename() != null)
+            {
+                try
+                {
+                    info.setColumns(getFileMetaData(logicalname, clustername));
+                }
+                catch (ArrayOfEspException e)
+                {
+                    if (e.getException().length > 0 && e.getException(0).getMessage() != null
+                            && e.getException(0).getMessage().contains("not available in service WsDfu"))
+                    {
+                        // for clusters on version < 5.0.2, this service doesn't exist; do it the old fashioned way
+                        info.setColumns(this.getFileDataColumns(logicalname, clustername));
                     }
                 }
-            }  
+            }
             return info;
         }
         catch (ArrayOfEspException e)
@@ -641,6 +647,6 @@ public class HPCCWsDFUClient extends DataSingleton
                 }
             }
             throw e;
-         }
+        }
     }
 }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUDataColumnInfo.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUDataColumnInfo.java
@@ -1,0 +1,81 @@
+package org.hpccsystems.ws.client.platform;
+
+import java.util.List;
+import org.hpccsystems.ws.client.gen.wsdfu.v1_29.DFUDataColumn;
+
+// This class wraps the generated soap ECL Workunit, providing comparable and to-string methods for end-users.
+public class DFUDataColumnInfo extends DFUDataColumn 
+{
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private List<DFUDataColumnInfo> childColumns=null;
+
+    /**
+     * Create a Data Column Info object from a axis-generated soap class DFUDataColumn
+     * 
+     * @param base
+     */
+    public DFUDataColumnInfo(DFUDataColumn base)
+    {
+        copy(base);
+    }
+
+    public DFUDataColumnInfo() {}
+
+       /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Object#toString()
+     */
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("ColumnEclType:").append(this.getColumnEclType()).append("\n");
+        sb.append("ColumnID:").append(this.getColumnID()).append("\n");
+        sb.append("ColumnLabel:").append(this.getColumnLabel()).append("\n");
+        sb.append("ColumnRawSize:").append(this.getColumnRawSize()).append("\n");
+        sb.append("ColumnSize:").append(this.getColumnSize()).append("\n");
+        sb.append("ColumnType:").append(this.getColumnType()).append("\n");
+        sb.append("ColumnValue:").append(this.getColumnValue()).append("\n");
+        sb.append("IsKeyedColumn:").append(this.getIsKeyedColumn()).append("\n");
+        sb.append("IsNaturalColumn:").append(this.getIsNaturalColumn()).append("\n");
+        sb.append("MaxSize:").append(this.getMaxSize()).append("\n");
+        return sb.toString();
+    }
+
+    /**
+     * Copy a soap ecl workunit object into the wrapper
+     * 
+     * @param base
+     */
+    private void copy(DFUDataColumn base)
+    {
+        if (base == null)
+        {
+            return;
+        }
+        this.setColumnEclType(base.getColumnEclType());
+        this.setColumnID(base.getColumnID());
+        this.setColumnLabel(base.getColumnLabel());
+        this.setColumnRawSize(base.getColumnRawSize());
+        this.setColumnSize(base.getColumnSize());
+        this.setColumnType(base.getColumnType());
+        this.setColumnValue(base.getColumnValue());
+        this.setIsKeyedColumn(base.getIsKeyedColumn());
+        this.setIsNaturalColumn(base.getIsNaturalColumn());
+        this.setMaxSize(base.getMaxSize());
+     }
+
+    public List<DFUDataColumnInfo> getChildColumns()
+    {
+        return childColumns;
+    }
+
+    public void setChildColumns(List<DFUDataColumnInfo> childColumns)
+    {
+        this.childColumns = childColumns;
+    }
+    
+}

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUDataColumnInfo.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUDataColumnInfo.java
@@ -1,16 +1,18 @@
 package org.hpccsystems.ws.client.platform;
 
+import java.util.ArrayList;
 import java.util.List;
+
 import org.hpccsystems.ws.client.gen.wsdfu.v1_29.DFUDataColumn;
 
 // This class wraps the generated soap ECL Workunit, providing comparable and to-string methods for end-users.
-public class DFUDataColumnInfo extends DFUDataColumn 
+public class DFUDataColumnInfo extends DFUDataColumn
 {
     /**
      * 
      */
-    private static final long serialVersionUID = 1L;
-    private List<DFUDataColumnInfo> childColumns=null;
+    private static final long       serialVersionUID = 1L;
+    private List<DFUDataColumnInfo> childColumns     = null;
 
     /**
      * Create a Data Column Info object from a axis-generated soap class DFUDataColumn
@@ -22,9 +24,11 @@ public class DFUDataColumnInfo extends DFUDataColumn
         copy(base);
     }
 
-    public DFUDataColumnInfo() {}
+    public DFUDataColumnInfo()
+    {
+    }
 
-       /*
+    /*
      * (non-Javadoc)
      * 
      * @see java.lang.Object#toString()
@@ -32,21 +36,24 @@ public class DFUDataColumnInfo extends DFUDataColumn
     public String toString()
     {
         StringBuilder sb = new StringBuilder();
-        sb.append("ColumnEclType:").append(this.getColumnEclType()).append("\n");
-        sb.append("ColumnID:").append(this.getColumnID()).append("\n");
-        sb.append("ColumnLabel:").append(this.getColumnLabel()).append("\n");
-        sb.append("ColumnRawSize:").append(this.getColumnRawSize()).append("\n");
-        sb.append("ColumnSize:").append(this.getColumnSize()).append("\n");
-        sb.append("ColumnType:").append(this.getColumnType()).append("\n");
-        sb.append("ColumnValue:").append(this.getColumnValue()).append("\n");
-        sb.append("IsKeyedColumn:").append(this.getIsKeyedColumn()).append("\n");
-        sb.append("IsNaturalColumn:").append(this.getIsNaturalColumn()).append("\n");
-        sb.append("MaxSize:").append(this.getMaxSize()).append("\n");
+        sb.append("\tColumnEclType:").append(this.getColumnEclType()).append("\n");
+        sb.append("\tColumnID:").append(this.getColumnID()).append("\n");
+        sb.append("\tColumnLabel:").append(this.getColumnLabel()).append("\n");
+        sb.append("\tColumnRawSize:").append(this.getColumnRawSize()).append("\n");
+        sb.append("\tColumnSize:").append(this.getColumnSize()).append("\n");
+        sb.append("\tColumnType:").append(this.getColumnType()).append("\n");
+        sb.append("\tColumnValue:").append(this.getColumnValue()).append("\n");
+        sb.append("\tIsKeyedColumn:").append(this.getIsKeyedColumn()).append("\n");
+        sb.append("\tIsNaturalColumn:").append(this.getIsNaturalColumn()).append("\n");
+        sb.append("\tMaxSize:").append(this.getMaxSize()).append("\n");
+        for (DFUDataColumnInfo col:this.getChildColumns()) {
+            sb.append("\t").append(col.getColumnLabel()).append(":").append(col.toString());
+        }
         return sb.toString();
     }
 
     /**
-     * Copy a soap ecl workunit object into the wrapper
+     * Copy a soap DFU Data Column object into the wrapper
      * 
      * @param base
      */
@@ -66,16 +73,45 @@ public class DFUDataColumnInfo extends DFUDataColumn
         this.setIsKeyedColumn(base.getIsKeyedColumn());
         this.setIsNaturalColumn(base.getIsNaturalColumn());
         this.setMaxSize(base.getMaxSize());
-     }
+    }
 
+    
+    /**
+     * @return list of child columns if this column is a dataset type column
+     */
     public List<DFUDataColumnInfo> getChildColumns()
     {
+        if (childColumns==null) {
+            return new ArrayList<DFUDataColumnInfo>();
+        }
         return childColumns;
     }
 
+    /**
+     * @param childColumns - List of DFUDataColumnInfo objects
+     */
     public void setChildColumns(List<DFUDataColumnInfo> childColumns)
     {
         this.childColumns = childColumns;
     }
     
+    /**
+     * @param childColumns - Array of DFUDataColumn objects
+     */
+    public void setColumns(DFUDataColumn[] childColumns)
+    {
+        if (childColumns==null) 
+        {
+            this.childColumns=null;
+            return;
+        }
+        this.childColumns=new ArrayList<DFUDataColumnInfo>();
+        for (int i=0; i < childColumns.length;i++) 
+        {
+            this.childColumns.add(new DFUDataColumnInfo(childColumns[i]));
+        }
+    }
+
+
+
 }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
@@ -6,19 +6,28 @@ import java.util.List;
 import org.hpccsystems.ws.client.gen.wsdfu.v1_29.DFUDataColumn;
 import org.hpccsystems.ws.client.gen.wsdfu.v1_29.DFUFileDetail;
 
-// This class wraps the generated soap ECL Workunit, providing comparable and to-string methods for end-users.
-public class DFUFileDetailInfo extends DFUFileDetail 
+// This class wraps the generated soap DFUFileDetail, providing additional features not yet available from the base esp
+// classes.
+/**
+ * @author LeedDX
+ *
+ */
+public class DFUFileDetailInfo extends DFUFileDetail
 {
-    public  static enum FileType{FLAT,CSV,XML,INDEX,UNKNOWN};
-    
+    public static enum FileType
+    {
+        FLAT, CSV, XML, INDEX, UNKNOWN
+    };
+
     /**
      * 
      */
-    private static final long serialVersionUID = 1L;
+    private static final long            serialVersionUID = 1L;
 
     private ArrayList<DFUDataColumnInfo> columns;
-    private String firstline=null;
-    private boolean hasheader=false;
+    private String                       firstline        = null;
+    private boolean                      hasheader        = false;
+
     public boolean hasHeader()
     {
         return hasheader;
@@ -39,13 +48,27 @@ public class DFUFileDetailInfo extends DFUFileDetail
         copy(base);
     }
 
-    public DFUFileDetailInfo() {}
+    /**
+     * Create an empty Data Column Info object
+     * 
+     * @param base
+     */
+    public DFUFileDetailInfo()
+    {
+    }
 
-       public String getFirstline()
+    /**
+     * @return the first line of data associated with this file
+     */
+    public String getFirstline()
     {
         return firstline;
     }
 
+    /**
+     * @param firstline
+     *            - set the first line of data associated with this file
+     */
     public void setFirstline(String firstline)
     {
         this.firstline = firstline;
@@ -75,11 +98,13 @@ public class DFUFileDetailInfo extends DFUFileDetail
         sb.append("Ecl:").append(this.getEcl()).append("\n");
         sb.append("Filename:").append(this.getFilename()).append("\n");
         sb.append("Filesize:").append(this.getFilesize()).append("\n");
+        sb.append("FirstLine:").append(this.getFirstline()).append("\n");
         sb.append("Format:").append(this.getFormat()).append("\n");
         sb.append("FromRoxieCluster:").append(this.getFromRoxieCluster()).append("\n");
         sb.append("Graphs:").append(this.getGraphs()).append("\n");
-        sb.append("IsCompressed:").append(this.getIsCompressed()).append("\n");
-        sb.append("IsSuperfile:").append(this.getIsSuperfile()).append("\n");
+        sb.append("hasHeader:").append(String.valueOf(this.hasHeader())).append("\n");
+        sb.append("IsCompressed:").append(String.valueOf(this.getIsCompressed())).append("\n");
+        sb.append("IsSuperfile:").append(String.valueOf(this.getIsSuperfile())).append("\n");
         sb.append("JobName:").append(this.getJobName()).append("\n");
         sb.append("MaxRecordSize:").append(this.getMaxRecordSize()).append("\n");
         sb.append("Modified:").append(this.getModified()).append("\n");
@@ -98,12 +123,17 @@ public class DFUFileDetailInfo extends DFUFileDetail
         sb.append("Superfiles:").append(this.getSuperfiles()).append("\n");
         sb.append("UserPermission:").append(this.getUserPermission()).append("\n");
         sb.append("Wuid:").append(this.getWuid()).append("\n");
-        sb.append("ZipFile:").append(this.getZipFile()).append("\n");  
+        sb.append("ZipFile:").append(this.getZipFile()).append("\n");
+        sb.append("Columns:");
+        for (DFUDataColumnInfo col : this.getColumns())
+        {
+            sb.append("    ").append(col.getColumnLabel()).append(":").append(col.toString());
+        }
         return sb.toString();
     }
 
     /**
-     * Copy a soap ecl workunit object into the wrapper
+     * Copy a soap DFUFileDetail object into the wrapper
      * 
      * @param base
      */
@@ -153,55 +183,81 @@ public class DFUFileDetailInfo extends DFUFileDetail
         this.setUserPermission(base.getUserPermission());
         this.setWuid(base.getWuid());
         this.setZipFile(base.getZipFile());
-     }
+    }
 
+    /**
+     * @return the columns for this logical file as defined in dfuGetMetadata or dfuGetDataColumns
+     */
     public ArrayList<DFUDataColumnInfo> getColumns()
     {
-        if (columns==null) {
+        if (columns == null)
+        {
             return new ArrayList<DFUDataColumnInfo>();
         }
         return columns;
     }
 
+    /**
+     * @param childColumns
+     *            - List of DFUDataColumns
+     */
     public void setColumns(List<DFUDataColumn> childColumns)
     {
-        if (childColumns==null) {
-            columns=null;
+        if (childColumns == null)
+        {
+            columns = null;
             return;
         }
-        columns=new ArrayList<DFUDataColumnInfo>();
-        for (int i=0; i < childColumns.size();i++) {
-            if (childColumns.get(i) instanceof DFUDataColumnInfo) {
+        columns = new ArrayList<DFUDataColumnInfo>();
+        for (int i = 0; i < childColumns.size(); i++)
+        {
+            if (childColumns.get(i) instanceof DFUDataColumnInfo)
+            {
                 columns.add((DFUDataColumnInfo) childColumns.get(i));
-            } else {
+            }
+            else
+            {
                 columns.add(new DFUDataColumnInfo(childColumns.get(i)));
             }
         }
 
     }
+
+    /**
+     * @param childColumns
+     *            - Array of DFUDataColumn objects
+     */
     public void setColumns(DFUDataColumn[] childColumns)
     {
-        if (childColumns==null) {
-            columns=null;
+        if (childColumns == null)
+        {
+            columns = null;
             return;
         }
-        columns=new ArrayList<DFUDataColumnInfo>();
-        for (int i=0; i < childColumns.length;i++) {
+        columns = new ArrayList<DFUDataColumnInfo>();
+        for (int i = 0; i < childColumns.length; i++)
+        {
             columns.add(new DFUDataColumnInfo(childColumns[i]));
         }
     }
 
-    public FileType getFileType() {
-    
-        if (this.getName()==null) {
+    /**
+     * @return the true FileType for this file, based on complex logic.
+     */
+    public FileType getFileType()
+    {
+
+        if (this.getName() == null)
+        {
             return FileType.UNKNOWN;
         }
-    
+
         // thor files store filetype in content type
-        boolean hasxpath=hasEcl() && getEcl().toLowerCase().contains("xpath");
-    
-        if ("flat".equalsIgnoreCase(getContentType())) {
-    
+        boolean hasxpath = hasEcl() && getEcl().toLowerCase().contains("xpath");
+
+        if ("flat".equalsIgnoreCase(getContentType()))
+        {
+
             // CSVs created by HPCC have file data; sprayed csvs return only
             // "line" from this call, and have their fields defined
             // in the record definition in the ecl attribute of dfu file info.
@@ -209,28 +265,33 @@ public class DFUFileDetailInfo extends DFUFileDetail
             {
                 return FileType.CSV;
             }
-    
+
             return FileType.FLAT;
         }
-        else if ("key".equalsIgnoreCase(getContentType())) {
+        else if ("key".equalsIgnoreCase(getContentType()))
+        {
             return FileType.INDEX;
         }
         else if (getContentType() == null || getContentType().equals(""))
         {
-            if (getFormat() != null && getFormat().equalsIgnoreCase("csv")) {
+            if (getFormat() != null && getFormat().equalsIgnoreCase("csv"))
+            {
                 return FileType.CSV;
             }
-            else if (getFormat() != null && getFormat().equalsIgnoreCase("xml")) {
+            else if (getFormat() != null && getFormat().equalsIgnoreCase("xml"))
+            {
                 return FileType.XML;
             }
             // csvs loaded as ascii get a format of "csv", csvs loaded as
             // utf-8 get a format of "utf8"
             if (getFormat().toLowerCase().startsWith("utf"))
             {
-                if (hasxpath) {
+                if (hasxpath)
+                {
                     return FileType.XML;
                 }
-                else {
+                else
+                {
                     return FileType.CSV;
                 }
             }
@@ -238,7 +299,7 @@ public class DFUFileDetailInfo extends DFUFileDetail
             {
                 // some HPCC-generated xml files use neither, check ecl
                 // record for xpath
-                    return FileType.XML;
+                return FileType.XML;
             }
             else if (hasEcl())
             {
@@ -248,80 +309,105 @@ public class DFUFileDetailInfo extends DFUFileDetail
             {
                 return FileType.UNKNOWN;
             }
-        } else {
+        }
+        else
+        {
             return FileType.UNKNOWN;
         }
     }
 
-    public boolean hasChildDatasets() {
-        if (this.getColumns().size()==0) {
+    /**
+     * @return true if the DFUDataColumns for this file contain items of type Dataset, false otherwise
+     */
+    public boolean hasChildDatasets()
+    {
+        if (this.getColumns().size() == 0)
+        {
             return false;
         }
-        for (DFUDataColumnInfo info:this.getColumns()) {
-            if ("table".equalsIgnoreCase(info.getColumnEclType())) {
+        for (DFUDataColumnInfo info : this.getColumns())
+        {
+            if ("table".equalsIgnoreCase(info.getColumnEclType()))
+            {
                 return true;
             }
         }
         return false;
     }
-    
-    public ArrayList<DFUDataColumnInfo> deduceFields() throws Exception {
 
-            if (FileType.FLAT.equals(getFileType()) || FileType.INDEX.equals(getFileType()))
+    /**
+     * @return the calculated DFUDataColumns based on the columns, deduced file type and ecl
+     * @throws Exception
+     */
+    public ArrayList<DFUDataColumnInfo> deduceFields() throws Exception
+    {
+
+        if (FileType.FLAT.equals(getFileType()) || FileType.INDEX.equals(getFileType()))
+        {
+            // until dfu metadata returns child dataset record structure,
+            // need to parse it from the ecl
+            if (hasChildDatasets())
             {
-                //until dfu metadata returns child dataset record structure, 
-                //need to parse it from the ecl
-                if (hasChildDatasets()) {
-                    return DFUFileDetailInfo.GetRecordFromECL(getEcl());
-                }
-                //return the columns populated from DFUGetMetadata (or DFUGetDataColumns from servers that don't have the Metadata 
-                //service yet
-                return getColumns();                
+                return DFUFileDetailInfo.GetRecordFromECL(getEcl());
             }
-            else if (FileType.XML.equals(getFileType())) {
-                if (hasEcl() && getColumns().size()==0)
+            // return the columns populated from DFUGetMetadata (or DFUGetDataColumns from servers that don't have the
+            // Metadata
+            // service yet
+            return getColumns();
+        }
+        else if (FileType.XML.equals(getFileType()))
+        {
+            if (hasEcl() && getColumns().size() == 0)
+            {
+                return GetRecordFromECL(getEcl());
+            }
+            return getColumns();
+        }
+        else if (FileType.CSV.equals(getFileType()))
+        {
+            // for csvs generated by thor, return columns retrieved from getDFUMetadata if they exist
+            if (getColumns().size() > 0 && !isSprayedCsv())
+            {
+                return getColumns();
+            }
+            // if there is no column information for a thor-generated csv, try to get the record from ecl
+            else if (hasEcl() && !isSprayedCsv())
+            {
+                return DFUFileDetailInfo.GetRecordFromECL(getEcl());
+            }
+            // for sprayed csvs or csvs with no ecl, try and figure this out from the first line of data
+            else if (getFirstline() != null && !getFirstline().isEmpty())
+            {
+                ArrayList<DFUDataColumnInfo> fields = new ArrayList<DFUDataColumnInfo>();
+                String[] flds = getFirstline().split(this.getCsvSeparate());
+                for (int i = 0; i < flds.length; i++)
                 {
-                    return GetRecordFromECL(getEcl());
-                } 
-                return getColumns();                
-            }
-            else if (FileType.CSV.equals(getFileType())) {                
-                //for csvs generated by thor, return columns retrieved from getDFUMetadata if they exist
-                if (getColumns().size()>0 && !isSprayedCsv()) {
-                    return getColumns();   
-                }
-                //if there is no column information for a thor-generated csv, try to get the record from ecl
-                else if (hasEcl() && !isSprayedCsv()) {
-                    return DFUFileDetailInfo.GetRecordFromECL(getEcl());
-                } 
-                //for sprayed csvs or csvs with no ecl, try and figure this out from the first line of data
-                else if (getFirstline() != null && !getFirstline().isEmpty()) {
-                    ArrayList<DFUDataColumnInfo> fields=new ArrayList<DFUDataColumnInfo>();
-                    String[] flds = getFirstline().split(this.getCsvSeparate());
-                    for (int i = 0; i < flds.length; i++)
+                    DFUDataColumn du = new DFUDataColumn();
+                    if (hasHeader() && isFirstRowValidFieldNames())
                     {
-                        DFUDataColumn du = new DFUDataColumn();
-                        if (hasHeader() && isFirstRowValidFieldNames()) {
-                            String fldval=flds[i].trim();
-                            if (this.getCsvQuote() != null && !this.getCsvQuote().isEmpty()
-                                    && fldval.startsWith(this.getCsvQuote())
-                                    && fldval.endsWith(this.getCsvQuote())) {
-                                fldval=fldval.substring(1, fldval.length()-1);
-                            }
-                            du.setColumnLabel(fldval);
-                        } else {
-                            du.setColumnLabel("Field" + String.valueOf(i + 1));
+                        String fldval = flds[i].trim();
+                        if (this.getCsvQuote() != null && !this.getCsvQuote().isEmpty()
+                                && fldval.startsWith(this.getCsvQuote()) && fldval.endsWith(this.getCsvQuote()))
+                        {
+                            fldval = fldval.substring(1, fldval.length() - 1);
                         }
-                        du.setColumnType("STRING");                       
-                        fields.add(new DFUDataColumnInfo(du));
+                        du.setColumnLabel(fldval);
                     }
-                    return fields;
+                    else
+                    {
+                        du.setColumnLabel("Field" + String.valueOf(i + 1));
+                    }
+                    du.setColumnType("STRING");
+                    fields.add(new DFUDataColumnInfo(du));
                 }
-                else {
-                    return getColumns();                        
-                }
+                return fields;
             }
-            return getColumns();                        
+            else
+            {
+                return getColumns();
+            }
+        }
+        return getColumns();
     }
 
     /**
@@ -334,7 +420,7 @@ public class DFUFileDetailInfo extends DFUFileDetail
      */
     public static ArrayList<DFUDataColumnInfo> GetRecordFromECL(String eclRecordDefinition) throws Exception
     {
-        String tempdef=null;
+        String tempdef = null;
         ArrayList<DFUDataColumnInfo> cols = new ArrayList<DFUDataColumnInfo>();
         eclRecordDefinition = eclRecordDefinition.replaceAll("(;|,|RECORD|\\{|\\})", "\n");
         eclRecordDefinition = eclRecordDefinition.replaceAll("RECORD", "RECORD\n");
@@ -351,8 +437,9 @@ public class DFUFileDetailInfo extends DFUFileDetail
             {
                 continue;
             }
-            else if (thisline.endsWith(":=")) {
-                tempdef=thisline.replace(":=", "");
+            else if (thisline.endsWith(":="))
+            {
+                tempdef = thisline.replace(":=", "");
                 continue;
             }
             // TODO: handle xml field definitions
@@ -365,8 +452,10 @@ public class DFUFileDetailInfo extends DFUFileDetail
             {
                 throw new Exception("Invalid record field definition " + thisline);
             }
-            if (!fieldargs[0].toUpperCase().matches(
-                    "(STRING|INTEGER|QSTRING|UTF|UNSIGNED|INTEGER|UNICODE|DATA|VARSTRING|VARUNICODE|DECIMAL|UDECIMAL|SET OF|DATASET|TYPEOF|RECORDOF|ENUM|REAL|BOOLEAN).*"))
+            if (!fieldargs[0]
+                    .toUpperCase()
+                    .matches(
+                            "(STRING|INTEGER|QSTRING|UTF|UNSIGNED|INTEGER|UNICODE|DATA|VARSTRING|VARUNICODE|DECIMAL|UDECIMAL|SET OF|DATASET|TYPEOF|RECORDOF|ENUM|REAL|BOOLEAN).*"))
             {
                 throw new Exception("Invalid record field type " + fieldargs[0]);
             }
@@ -379,46 +468,60 @@ public class DFUFileDetailInfo extends DFUFileDetail
         return cols;
     }
 
-    public boolean isSprayedCsv() {
-       if ("line".equals(getColumns().get(0).getColumnLabel())
-               && getColumns().size() != 2) {
-           int i=0;
-       }
-        return  getColumns() != null
-                && getColumns().size()==2
-                && "line".equals(getColumns().get(0).getColumnLabel());
+    /**
+     * @return true if this file shows the attributes of having been a sprayed csv , false otherwise
+     */
+    public boolean isSprayedCsv()
+    {
+        if ("line".equals(getColumns().get(0).getColumnLabel()) && getColumns().size() != 2)
+        {
+            int i = 0;
+        }
+        return getColumns() != null && getColumns().size() == 2 && "line".equals(getColumns().get(0).getColumnLabel());
     }
-    
-    public boolean hasEcl() {
+
+    /**
+     * @return true if getEcl is populated, false otherwise
+     */
+    public boolean hasEcl()
+    {
         return (getEcl() != null && !getEcl().isEmpty());
     }
-    
-    public boolean isFirstRowValidFieldNames() {
-        if (!FileType.CSV.equals(getFileType())) {
+
+    /**
+     * @return true if the data file is a csv, if the first row of data is populated and if the values in that line,
+     *         when split on the defined field separator, are valid ecl field names. Return false otherwise.
+     */
+    public boolean isFirstRowValidFieldNames()
+    {
+        if (!FileType.CSV.equals(getFileType()))
+        {
             return false;
         }
-        if (this.getFirstline()==null || this.getFirstline().isEmpty())
+        if (this.getFirstline() == null || this.getFirstline().isEmpty())
         {
             return false;
         }
         String[] flds = getFirstline().split(this.getCsvSeparate());
-        if (!this.isSprayedCsv() && flds.length!=getColumns().size()) {
+        if (!this.isSprayedCsv() && flds.length != getColumns().size())
+        {
             return false;
         }
         for (int i = 0; i < flds.length; i++)
         {
-            String fldval=flds[i].trim();
-            if (this.getCsvQuote() != null && !this.getCsvQuote().isEmpty()
-                    && fldval.startsWith(this.getCsvQuote())
-                    && fldval.endsWith(this.getCsvQuote())) {
-                fldval=fldval.substring(1, fldval.length()-1);
+            String fldval = flds[i].trim();
+            if (this.getCsvQuote() != null && !this.getCsvQuote().isEmpty() && fldval.startsWith(this.getCsvQuote())
+                    && fldval.endsWith(this.getCsvQuote()))
+            {
+                fldval = fldval.substring(1, fldval.length() - 1);
             }
-            String fld=fldval.replaceAll("[^A-Za-z0-9_]", "");
-            if (!fld.equals(fldval)) {
+            String fld = fldval.replaceAll("[^A-Za-z0-9_]", "");
+            if (!fld.equals(fldval))
+            {
                 return false;
             }
         }
         return true;
     }
-    
+
 }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
@@ -1,0 +1,424 @@
+package org.hpccsystems.ws.client.platform;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hpccsystems.ws.client.gen.wsdfu.v1_29.DFUDataColumn;
+import org.hpccsystems.ws.client.gen.wsdfu.v1_29.DFUFileDetail;
+
+// This class wraps the generated soap ECL Workunit, providing comparable and to-string methods for end-users.
+public class DFUFileDetailInfo extends DFUFileDetail 
+{
+    public  static enum FileType{FLAT,CSV,XML,INDEX,UNKNOWN};
+    
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+
+    private ArrayList<DFUDataColumnInfo> columns;
+    private String firstline=null;
+    private boolean hasheader=false;
+    public boolean hasHeader()
+    {
+        return hasheader;
+    }
+
+    public void setHasHeader(boolean hasheader)
+    {
+        this.hasheader = hasheader;
+    }
+
+    /**
+     * Create a Data Column Info object from a axis-generated soap class DFUDataColumn
+     * 
+     * @param base
+     */
+    public DFUFileDetailInfo(DFUFileDetail base)
+    {
+        copy(base);
+    }
+
+    public DFUFileDetailInfo() {}
+
+       public String getFirstline()
+    {
+        return firstline;
+    }
+
+    public void setFirstline(String firstline)
+    {
+        this.firstline = firstline;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Object#toString()
+     */
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("ActualSize:").append(this.getActualSize()).append("\n");
+        sb.append("BrowseData:").append(this.getBrowseData()).append("\n");
+        sb.append("Cluster:").append(this.getCluster()).append("\n");
+        sb.append("CompressedFileSize:").append(this.getCompressedFileSize()).append("\n");
+        sb.append("ContentType:").append(this.getContentType()).append("\n");
+        sb.append("CsvEscape:").append(this.getCsvEscape()).append("\n");
+        sb.append("CsvQuote:").append(this.getCsvQuote()).append("\n");
+        sb.append("CsvSeparate:").append(this.getCsvSeparate()).append("\n");
+        sb.append("CsvTerminate:").append(this.getCsvTerminate()).append("\n");
+        sb.append("Description:").append(this.getDescription()).append("\n");
+        sb.append("DFUFileParts:").append(this.getDFUFileParts()).append("\n");
+        sb.append("DFUFilePartsOnClusters:").append(this.getDFUFilePartsOnClusters()).append("\n");
+        sb.append("Dir:").append(this.getDir()).append("\n");
+        sb.append("Ecl:").append(this.getEcl()).append("\n");
+        sb.append("Filename:").append(this.getFilename()).append("\n");
+        sb.append("Filesize:").append(this.getFilesize()).append("\n");
+        sb.append("Format:").append(this.getFormat()).append("\n");
+        sb.append("FromRoxieCluster:").append(this.getFromRoxieCluster()).append("\n");
+        sb.append("Graphs:").append(this.getGraphs()).append("\n");
+        sb.append("IsCompressed:").append(this.getIsCompressed()).append("\n");
+        sb.append("IsSuperfile:").append(this.getIsSuperfile()).append("\n");
+        sb.append("JobName:").append(this.getJobName()).append("\n");
+        sb.append("MaxRecordSize:").append(this.getMaxRecordSize()).append("\n");
+        sb.append("Modified:").append(this.getModified()).append("\n");
+        sb.append("Name:").append(this.getName()).append("\n");
+        sb.append("NodeGroup:").append(this.getNodeGroup()).append("\n");
+        sb.append("NumParts:").append(this.getNumParts()).append("\n");
+        sb.append("Owner:").append(this.getOwner()).append("\n");
+        sb.append("PathMask:").append(this.getPathMask()).append("\n");
+        sb.append("Persistent:").append(this.getPersistent()).append("\n");
+        sb.append("Prefix:").append(this.getPrefix()).append("\n");
+        sb.append("RecordCount:").append(this.getRecordCount()).append("\n");
+        sb.append("RecordSize:").append(this.getRecordSize()).append("\n");
+        sb.append("ShowFileContent:").append(this.getShowFileContent()).append("\n");
+        sb.append("Stat:").append(this.getStat()).append("\n");
+        sb.append("Subfiles:").append(this.getSubfiles()).append("\n");
+        sb.append("Superfiles:").append(this.getSuperfiles()).append("\n");
+        sb.append("UserPermission:").append(this.getUserPermission()).append("\n");
+        sb.append("Wuid:").append(this.getWuid()).append("\n");
+        sb.append("ZipFile:").append(this.getZipFile()).append("\n");  
+        return sb.toString();
+    }
+
+    /**
+     * Copy a soap ecl workunit object into the wrapper
+     * 
+     * @param base
+     */
+    private void copy(DFUFileDetail base)
+    {
+        if (base == null)
+        {
+            return;
+        }
+        this.setActualSize(base.getActualSize());
+        this.setBrowseData(base.getBrowseData());
+        this.setCluster(base.getCluster());
+        this.setCompressedFileSize(base.getCompressedFileSize());
+        this.setContentType(base.getContentType());
+        this.setCsvEscape(base.getCsvEscape());
+        this.setCsvQuote(base.getCsvQuote());
+        this.setCsvSeparate(base.getCsvSeparate());
+        this.setCsvTerminate(base.getCsvTerminate());
+        this.setDescription(base.getDescription());
+        this.setDFUFileParts(base.getDFUFileParts());
+        this.setDFUFilePartsOnClusters(base.getDFUFilePartsOnClusters());
+        this.setDir(base.getDir());
+        this.setEcl(base.getEcl());
+        this.setFilename(base.getFilename());
+        this.setFilesize(base.getFilesize());
+        this.setFormat(base.getFormat());
+        this.setFromRoxieCluster(base.getFromRoxieCluster());
+        this.setGraphs(base.getGraphs());
+        this.setIsCompressed(base.getIsCompressed());
+        this.setIsSuperfile(base.getIsSuperfile());
+        this.setJobName(base.getJobName());
+        this.setMaxRecordSize(base.getMaxRecordSize());
+        this.setModified(base.getModified());
+        this.setName(base.getName());
+        this.setNodeGroup(base.getNodeGroup());
+        this.setNumParts(base.getNumParts());
+        this.setOwner(base.getOwner());
+        this.setPathMask(base.getPathMask());
+        this.setPersistent(base.getPersistent());
+        this.setPrefix(base.getPrefix());
+        this.setRecordCount(base.getRecordCount());
+        this.setRecordSize(base.getRecordSize());
+        this.setShowFileContent(base.getShowFileContent());
+        this.setStat(base.getStat());
+        this.setSubfiles(base.getSubfiles());
+        this.setSuperfiles(base.getSuperfiles());
+        this.setUserPermission(base.getUserPermission());
+        this.setWuid(base.getWuid());
+        this.setZipFile(base.getZipFile());
+     }
+
+    public ArrayList<DFUDataColumnInfo> getColumns()
+    {
+        if (columns==null) {
+            return new ArrayList<DFUDataColumnInfo>();
+        }
+        return columns;
+    }
+
+    public void setColumns(List<DFUDataColumn> childColumns)
+    {
+        if (childColumns==null) {
+            columns=null;
+            return;
+        }
+        columns=new ArrayList<DFUDataColumnInfo>();
+        for (int i=0; i < childColumns.size();i++) {
+            if (childColumns.get(i) instanceof DFUDataColumnInfo) {
+                columns.add((DFUDataColumnInfo) childColumns.get(i));
+            } else {
+                columns.add(new DFUDataColumnInfo(childColumns.get(i)));
+            }
+        }
+
+    }
+    public void setColumns(DFUDataColumn[] childColumns)
+    {
+        if (childColumns==null) {
+            columns=null;
+            return;
+        }
+        columns=new ArrayList<DFUDataColumnInfo>();
+        for (int i=0; i < childColumns.length;i++) {
+            columns.add(new DFUDataColumnInfo(childColumns[i]));
+        }
+    }
+
+    public FileType getFileType() {
+    
+        if (this.getName()==null) {
+            return FileType.UNKNOWN;
+        }
+    
+        // thor files store filetype in content type
+        boolean hasxpath=hasEcl() && getEcl().toLowerCase().contains("xpath");
+    
+        if ("flat".equalsIgnoreCase(getContentType())) {
+    
+            // CSVs created by HPCC have file data; sprayed csvs return only
+            // "line" from this call, and have their fields defined
+            // in the record definition in the ecl attribute of dfu file info.
+            if (!hasEcl() && this.isSprayedCsv())
+            {
+                return FileType.CSV;
+            }
+    
+            return FileType.FLAT;
+        }
+        else if ("key".equalsIgnoreCase(getContentType())) {
+            return FileType.INDEX;
+        }
+        else if (getContentType() == null || getContentType().equals(""))
+        {
+            if (getFormat() != null && getFormat().equalsIgnoreCase("csv")) {
+                return FileType.CSV;
+            }
+            else if (getFormat() != null && getFormat().equalsIgnoreCase("xml")) {
+                return FileType.XML;
+            }
+            // csvs loaded as ascii get a format of "csv", csvs loaded as
+            // utf-8 get a format of "utf8"
+            if (getFormat().toLowerCase().startsWith("utf"))
+            {
+                if (hasxpath) {
+                    return FileType.XML;
+                }
+                else {
+                    return FileType.CSV;
+                }
+            }
+            else if ((getFormat() == null || getFormat().equals("")) && hasxpath)
+            {
+                // some HPCC-generated xml files use neither, check ecl
+                // record for xpath
+                    return FileType.XML;
+            }
+            else if (hasEcl())
+            {
+                return FileType.FLAT;
+            }
+            else
+            {
+                return FileType.UNKNOWN;
+            }
+        } else {
+            return FileType.UNKNOWN;
+        }
+    }
+
+    public boolean hasChildDatasets() {
+        if (this.getColumns().size()==0) {
+            return false;
+        }
+        for (DFUDataColumnInfo info:this.getColumns()) {
+            if ("table".equalsIgnoreCase(info.getColumnEclType())) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    public ArrayList<DFUDataColumnInfo> deduceFields() throws Exception {
+
+            if (FileType.FLAT.equals(getFileType()) || FileType.INDEX.equals(getFileType()))
+            {
+                //until dfu metadata returns child dataset record structure, 
+                //need to parse it from the ecl
+                if (hasChildDatasets()) {
+                    return DFUFileDetailInfo.GetRecordFromECL(getEcl());
+                }
+                //return the columns populated from DFUGetMetadata (or DFUGetDataColumns from servers that don't have the Metadata 
+                //service yet
+                return getColumns();                
+            }
+            else if (FileType.XML.equals(getFileType())) {
+                if (hasEcl() && getColumns().size()==0)
+                {
+                    return GetRecordFromECL(getEcl());
+                } 
+                return getColumns();                
+            }
+            else if (FileType.CSV.equals(getFileType())) {                
+                //for csvs generated by thor, return columns retrieved from getDFUMetadata if they exist
+                if (getColumns().size()>0 && !isSprayedCsv()) {
+                    return getColumns();   
+                }
+                //if there is no column information for a thor-generated csv, try to get the record from ecl
+                else if (hasEcl() && !isSprayedCsv()) {
+                    return DFUFileDetailInfo.GetRecordFromECL(getEcl());
+                } 
+                //for sprayed csvs or csvs with no ecl, try and figure this out from the first line of data
+                else if (getFirstline() != null && !getFirstline().isEmpty()) {
+                    ArrayList<DFUDataColumnInfo> fields=new ArrayList<DFUDataColumnInfo>();
+                    String[] flds = getFirstline().split(this.getCsvSeparate());
+                    for (int i = 0; i < flds.length; i++)
+                    {
+                        DFUDataColumn du = new DFUDataColumn();
+                        if (hasHeader() && isFirstRowValidFieldNames()) {
+                            String fldval=flds[i].trim();
+                            if (this.getCsvQuote() != null && !this.getCsvQuote().isEmpty()
+                                    && fldval.startsWith(this.getCsvQuote())
+                                    && fldval.endsWith(this.getCsvQuote())) {
+                                fldval=fldval.substring(1, fldval.length()-1);
+                            }
+                            du.setColumnLabel(fldval);
+                        } else {
+                            du.setColumnLabel("Field" + String.valueOf(i + 1));
+                        }
+                        du.setColumnType("STRING");                       
+                        fields.add(new DFUDataColumnInfo(du));
+                    }
+                    return fields;
+                }
+                else {
+                    return getColumns();                        
+                }
+            }
+            return getColumns();                        
+    }
+
+    /**
+     * @param eclRecordDefinition
+     *            - a RECORD definition, either in RECORD\nSTRING1\nEND; format, or in {STRING1 field} inline format,.
+     *            currently handles XPATH recordsets but doesn't save XPATH info. A few issues with child dataset
+     *            records
+     * @return An ArrayList of DFUDataColumns
+     * @throws Exception
+     */
+    public static ArrayList<DFUDataColumnInfo> GetRecordFromECL(String eclRecordDefinition) throws Exception
+    {
+        String tempdef=null;
+        ArrayList<DFUDataColumnInfo> cols = new ArrayList<DFUDataColumnInfo>();
+        eclRecordDefinition = eclRecordDefinition.replaceAll("(;|,|RECORD|\\{|\\})", "\n");
+        eclRecordDefinition = eclRecordDefinition.replaceAll("RECORD", "RECORD\n");
+        eclRecordDefinition = eclRecordDefinition.replaceAll("\n\n", "\n");
+        String[] lines = eclRecordDefinition.split("\n");
+        for (int i = 0; i < lines.length; i++)
+        {
+            String thisline = lines[i].trim();
+            if (thisline.equals(""))
+            {
+                continue;
+            }
+            if (thisline.matches("(RECORD|END|\\{|\\})"))
+            {
+                continue;
+            }
+            else if (thisline.endsWith(":=")) {
+                tempdef=thisline.replace(":=", "");
+                continue;
+            }
+            // TODO: handle xml field definitions
+            if (thisline.toLowerCase().contains("xpath"))
+            {
+                continue;
+            }
+            String[] fieldargs = thisline.split(" ");
+            if (fieldargs.length < 2)
+            {
+                throw new Exception("Invalid record field definition " + thisline);
+            }
+            if (!fieldargs[0].toUpperCase().matches(
+                    "(STRING|INTEGER|QSTRING|UTF|UNSIGNED|INTEGER|UNICODE|DATA|VARSTRING|VARUNICODE|DECIMAL|UDECIMAL|SET OF|DATASET|TYPEOF|RECORDOF|ENUM|REAL|BOOLEAN).*"))
+            {
+                throw new Exception("Invalid record field type " + fieldargs[0]);
+            }
+            DFUDataColumnInfo col = new DFUDataColumnInfo();
+            col.setColumnType(fieldargs[0].toUpperCase());
+            col.setColumnEclType(fieldargs[0].toUpperCase());
+            col.setColumnLabel(fieldargs[1]);
+            cols.add(col);
+        }
+        return cols;
+    }
+
+    public boolean isSprayedCsv() {
+       if ("line".equals(getColumns().get(0).getColumnLabel())
+               && getColumns().size() != 2) {
+           int i=0;
+       }
+        return  getColumns() != null
+                && getColumns().size()==2
+                && "line".equals(getColumns().get(0).getColumnLabel());
+    }
+    
+    public boolean hasEcl() {
+        return (getEcl() != null && !getEcl().isEmpty());
+    }
+    
+    public boolean isFirstRowValidFieldNames() {
+        if (!FileType.CSV.equals(getFileType())) {
+            return false;
+        }
+        if (this.getFirstline()==null || this.getFirstline().isEmpty())
+        {
+            return false;
+        }
+        String[] flds = getFirstline().split(this.getCsvSeparate());
+        if (!this.isSprayedCsv() && flds.length!=getColumns().size()) {
+            return false;
+        }
+        for (int i = 0; i < flds.length; i++)
+        {
+            String fldval=flds[i].trim();
+            if (this.getCsvQuote() != null && !this.getCsvQuote().isEmpty()
+                    && fldval.startsWith(this.getCsvQuote())
+                    && fldval.endsWith(this.getCsvQuote())) {
+                fldval=fldval.substring(1, fldval.length()-1);
+            }
+            String fld=fldval.replaceAll("[^A-Za-z0-9_]", "");
+            if (!fld.equals(fldval)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+}

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
@@ -198,26 +198,26 @@ public class DFUFileDetailInfo extends DFUFileDetail
     }
 
     /**
-     * @param childColumns
+     * @param columns
      *            - List of DFUDataColumns
      */
-    public void setColumns(List<DFUDataColumn> childColumns)
+    public void setColumns(List<DFUDataColumn> columns)
     {
-        if (childColumns == null)
+        if (columns == null)
         {
-            columns = null;
+            this.columns = null;
             return;
         }
-        columns = new ArrayList<DFUDataColumnInfo>();
-        for (int i = 0; i < childColumns.size(); i++)
+        this.columns = new ArrayList<DFUDataColumnInfo>();
+        for (int i = 0; i < columns.size(); i++)
         {
-            if (childColumns.get(i) instanceof DFUDataColumnInfo)
+            if (columns.get(i) instanceof DFUDataColumnInfo)
             {
-                columns.add((DFUDataColumnInfo) childColumns.get(i));
+                this.columns.add((DFUDataColumnInfo) columns.get(i));
             }
             else
             {
-                columns.add(new DFUDataColumnInfo(childColumns.get(i)));
+                this.columns.add(new DFUDataColumnInfo(columns.get(i)));
             }
         }
 
@@ -274,11 +274,11 @@ public class DFUFileDetailInfo extends DFUFileDetail
         }
         else if (getContentType() == null || getContentType().equals(""))
         {
-            if (getFormat() != null && getFormat().equalsIgnoreCase("csv"))
+            if (FileType.CSV.toString().equalsIgnoreCase(getFormat()))
             {
                 return FileType.CSV;
             }
-            else if (getFormat() != null && getFormat().equalsIgnoreCase("xml"))
+            else if (FileType.XML.toString().equalsIgnoreCase(getFormat()))
             {
                 return FileType.XML;
             }


### PR DESCRIPTION
for #99, Added two new wrapper classes for the ajax-generated DFUDataColumn and DFUFileDetail classes,  DFUDataColumnInfo and DFUFileDetailInfo.

Moved the calculation of the file type & file fields into DFUFileDetailInfo.
