### PR TITLE
JAPI-14

### DIFF
--- a/wsclient/pom.xml
+++ b/wsclient/pom.xml
@@ -10,8 +10,27 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <build>
+    <scm>
+        <connection>scm:git:git@github.com:hpcc-systems/HPCC-JAPIs.git</connection>
+        <developerConnection>scm:git:git@github.com:hpcc-systems/HPCC-JAPIs.git</developerConnection>
+        <url>scm:git@github.com:hpcc-systems/HPCC-JAPIs.git</url>
+        <tag>HEAD</tag>
+    </scm>
 
+	<distributionManagement>
+	  <repository>
+	     <id>deployment</id>
+	     <name>Internal Releases</name>
+	     <url>http://mvnrisk.lexisnexis.com:8081/nexus/content/repositories/releases/</url>
+	  </repository>
+	  <snapshotRepository>
+	     <id>deployment</id>
+	     <name>Internal Releases</name>
+	     <url>http://mvnrisk.lexisnexis.com:8081/nexus/content/repositories/snapshots/</url>
+	  </snapshotRepository>
+	</distributionManagement>
+ 
+  <build>
     <plugins>
       <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Adding scm and distributionManagement metadata to support a maven-based release. (untested)