### PR TITLE
JAPI-17 Clean up fileformat enum

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCFileSprayClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCFileSprayClient.java
@@ -10,6 +10,7 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.HashMap;
 import java.util.Properties;
 
 import org.apache.axis.client.Stub;
@@ -50,6 +51,58 @@ import org.hpccsystems.ws.client.utils.Utils;
  */
 public class HPCCFileSprayClient extends DataSingleton
 {
+    //from HPCC-Platform/dali/dfu/dfuwu.hpp DFUfileformat
+    public enum SprayVariableFormat
+    {
+        DFUff_fixed(0),
+        DFUff_csv(1),
+        DFUff_ascii(1),
+        DFUff_utf8(2),
+        DFUff_utf8n(3),
+        DFUff_utf16(4),
+        DFUff_utf16le(5),
+        DFUff_utf16be(6),
+        DFUff_utf32(7),
+        DFUff_utf32le(8),
+        DFUff_utf32be(9),
+        DFUff_variable(10),
+        DFUff_recfmvb(11),
+        DFUff_recfmv(12),
+        DFUff_variablebigendian(13);
+
+        private final int id;
+        SprayVariableFormat(int id) { this.id = id; }
+        public int getValue() { return id; }
+
+        private final static HashMap<String, SprayVariableFormat> mapVariableSprayFormatNameCode = new HashMap<String, SprayVariableFormat>();
+        static
+        {
+            mapVariableSprayFormatNameCode.put("csv",                SprayVariableFormat.DFUff_csv);
+            mapVariableSprayFormatNameCode.put("ascii",              SprayVariableFormat.DFUff_ascii);
+            mapVariableSprayFormatNameCode.put("utf8",               SprayVariableFormat.DFUff_utf8);
+            mapVariableSprayFormatNameCode.put("utf16",              SprayVariableFormat.DFUff_utf16);
+            mapVariableSprayFormatNameCode.put("utf16le",            SprayVariableFormat.DFUff_utf16le);
+            mapVariableSprayFormatNameCode.put("utf16be",            SprayVariableFormat.DFUff_utf16be);
+            mapVariableSprayFormatNameCode.put("utf32",              SprayVariableFormat.DFUff_utf32);
+            mapVariableSprayFormatNameCode.put("utf32le",            SprayVariableFormat.DFUff_utf32le);
+            mapVariableSprayFormatNameCode.put("utf32be",            SprayVariableFormat.DFUff_utf32be);
+            mapVariableSprayFormatNameCode.put("variable",           SprayVariableFormat.DFUff_variable);
+            mapVariableSprayFormatNameCode.put("recfmvb",            SprayVariableFormat.DFUff_recfmvb);
+            mapVariableSprayFormatNameCode.put("recfmv",             SprayVariableFormat.DFUff_recfmv);
+            mapVariableSprayFormatNameCode.put("variablebigendian",  SprayVariableFormat.DFUff_variablebigendian);
+            mapVariableSprayFormatNameCode.put("fixed",              SprayVariableFormat.DFUff_fixed);
+        }
+
+        public static SprayVariableFormat convertVarSprayFormatName2Code(String varSprayFormatName)
+        {
+            String lower = varSprayFormatName.toLowerCase();
+            if(mapVariableSprayFormatNameCode.containsKey(lower))
+                return mapVariableSprayFormatNameCode.get(lower);
+            else
+                return SprayVariableFormat.DFUff_fixed;
+        }
+    }
+
     private static URL                  originalURL;
 
     public static URL getOriginalURL() throws MalformedURLException
@@ -346,7 +399,7 @@ public class HPCCFileSprayClient extends DataSingleton
      * @return                 - Progress response at time of request
      * @throws Exception
      */
-    public ProgressResponse sprayVariableLocalDropZone(DelimitedDataOptions options, String sourceFileName, String targetFileName, String prefix, String destGroup, boolean overwrite, FileFormat format) throws Exception
+    public ProgressResponse sprayVariableLocalDropZone(DelimitedDataOptions options, String sourceFileName, String targetFileName, String prefix, String destGroup, boolean overwrite, SprayVariableFormat format) throws Exception
     {
         if (localDropZones == null)
             localDropZones = fetchLocalDropZones();
@@ -368,7 +421,7 @@ public class HPCCFileSprayClient extends DataSingleton
      */
     public ProgressResponse sprayVariable(DelimitedDataOptions options, DropZone targetDropZone, String sourceFileName, String targetFileName, String prefix, String destGroup, boolean overwrite) throws Exception
     {
-        return sprayVariable(options, targetDropZone, sourceFileName, targetFileName, prefix, destGroup, overwrite, FileFormat.DFUff_csv);
+        return sprayVariable(options, targetDropZone, sourceFileName, targetFileName, prefix, destGroup, overwrite, SprayVariableFormat.DFUff_csv);
     }
 
     /**
@@ -383,7 +436,7 @@ public class HPCCFileSprayClient extends DataSingleton
      * @return                 - Progress response at time of request
      * @throws Exception
      */
-    public ProgressResponse sprayVariable(DelimitedDataOptions options, DropZone targetDropZone, String sourceFileName, String targetFileName, String prefix, String destGroup, boolean overwrite, FileFormat format) throws Exception
+    public ProgressResponse sprayVariable(DelimitedDataOptions options, DropZone targetDropZone, String sourceFileName, String targetFileName, String prefix, String destGroup, boolean overwrite, SprayVariableFormat format) throws Exception
     {
         if (fileSprayServiceSoapProxy == null)
             throw new Exception("FileSpray Service Soap Proxy not available.");
@@ -441,7 +494,7 @@ public class HPCCFileSprayClient extends DataSingleton
         if (localDropZones == null)
             localDropZones = fetchLocalDropZones();
 
-        return sprayXML(localDropZones[0], sourceFileName, targetFileName, prefix, destGroup, "tag", overwrite, FileFormat.DFUff_ascii, 8192);
+        return sprayXML(localDropZones[0], sourceFileName, targetFileName, prefix, destGroup, "tag", overwrite, SprayVariableFormat.DFUff_ascii, 8192);
     }
 
     /**
@@ -458,7 +511,7 @@ public class HPCCFileSprayClient extends DataSingleton
      * @return ProgressResponse
      * @throws Exception
      */
-    public ProgressResponse sprayLocalXML(String sourceFileName, String targetFileName, String prefix, String destGroup, boolean overwrite, FileFormat format, String rowtag, Integer maxrecsize) throws Exception
+    public ProgressResponse sprayLocalXML(String sourceFileName, String targetFileName, String prefix, String destGroup, boolean overwrite, SprayVariableFormat format, String rowtag, Integer maxrecsize) throws Exception
     {
         if (localDropZones == null)
             localDropZones = fetchLocalDropZones();
@@ -481,7 +534,7 @@ public class HPCCFileSprayClient extends DataSingleton
      * @return ProgressResponse
      * @throws Exception
      */
-    public ProgressResponse sprayXML(DropZone targetDropZone, String sourceFileName, String targetFileName, String prefix, String destGroup, String rowtag , boolean overwrite, FileFormat format, Integer maxrecsize) throws Exception
+    public ProgressResponse sprayXML(DropZone targetDropZone, String sourceFileName, String targetFileName, String prefix, String destGroup, String rowtag , boolean overwrite, SprayVariableFormat format, Integer maxrecsize) throws Exception
     {
         if (fileSprayServiceSoapProxy == null)
             throw new Exception("FileSpray Service Soap Proxy not available.");

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsClient.java
@@ -5,6 +5,7 @@ import java.net.MalformedURLException;
 import java.rmi.RemoteException;
 import java.util.List;
 
+import org.hpccsystems.ws.client.HPCCFileSprayClient.SprayVariableFormat;
 import org.hpccsystems.ws.client.extended.HPCCWsAttributesClient;
 import org.hpccsystems.ws.client.extended.HPCCWsSQLClient;
 import org.hpccsystems.ws.client.gen.filespray.v1_06.EspException;
@@ -533,7 +534,7 @@ public class HPCCWsClient extends DataSingleton
      * @param overwritesprayedfile    - Boolean, overwrite possibly sprayed file of same name
      * @return                        - Boolean, success.
      */
-    public boolean sprayCustomCSVHPCCFile(String fileName, String targetFileLabel, String targetCluster, String escapedEscapeSequence, String escapedFieldDelim, String escapedQuote, String escapedRecTerminator, boolean overwritesprayedfile, FileFormat format)
+    public boolean sprayCustomCSVHPCCFile(String fileName, String targetFileLabel, String targetCluster, String escapedEscapeSequence, String escapedFieldDelim, String escapedQuote, String escapedRecTerminator, boolean overwritesprayedfile, SprayVariableFormat format)
     {
         boolean success = true;
 
@@ -566,7 +567,7 @@ public class HPCCWsClient extends DataSingleton
         {
             //Another way is to create the enumeration from the string representation...
             //FileFormat.convertDFUFileFormatName2Code("csv");
-            success = sprayVariableHPCCFile(fileName, targetFileLabel, targetCluster, new DelimitedDataOptions(), overwritesprayedfile, FileFormat.DFUff_csv); //could be
+            success = sprayVariableHPCCFile(fileName, targetFileLabel, targetCluster, new DelimitedDataOptions(), overwritesprayedfile, SprayVariableFormat.DFUff_csv); //could be
         }
         catch (Exception e)
         {
@@ -586,7 +587,7 @@ public class HPCCWsClient extends DataSingleton
      * @param format                  - FileFormat
      * @return                        - Boolean, success.
      */
-    public boolean sprayVariableHPCCFile(String fileName, String targetFileLabel, String targetCluster, DelimitedDataOptions options, boolean overwritesprayedfile, FileFormat format)
+    public boolean sprayVariableHPCCFile(String fileName, String targetFileLabel, String targetCluster, DelimitedDataOptions options, boolean overwritesprayedfile, SprayVariableFormat format)
     {
         boolean success = false;
 

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
@@ -265,8 +265,7 @@ public class DFUFileDetailInfo extends DFUFileDetail
         {
             return FileFormat.KEYED;
         }
-        //else if (getContentType() == null || getContentType().equals(""))
-        else if (fileFormatFromContent == null)
+        else if (fileFormatFromContent == FileFormat.UNKNOWN && (getContentType() == null || getContentType().equals("")))
         {
             FileFormat fileFormat = FileFormat.getFileFormat(getFormat());
             if (FileFormat.CSV == fileFormat)
@@ -290,7 +289,7 @@ public class DFUFileDetailInfo extends DFUFileDetail
                     return FileFormat.CSV;
                 }
             }
-            else if (fileFormat == null && hasxpath)
+            else if (fileFormat == FileFormat.UNKNOWN && (getFormat() == null || getFormat().equals("")) && hasxpath)
             {
                 // some HPCC-generated xml files use neither, check ecl
                 // record for xpath

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.hpccsystems.ws.client.gen.wsdfu.v1_29.DFUDataColumn;
 import org.hpccsystems.ws.client.gen.wsdfu.v1_29.DFUFileDetail;
+import org.hpccsystems.ws.client.utils.FileFormat;
 
 // This class wraps the generated soap DFUFileDetail, providing additional features not yet available from the base esp
 // classes.
@@ -14,14 +15,6 @@ import org.hpccsystems.ws.client.gen.wsdfu.v1_29.DFUFileDetail;
  */
 public class DFUFileDetailInfo extends DFUFileDetail
 {
-    public static enum FileType
-    {
-        FLAT, CSV, XML, INDEX, UNKNOWN
-    };
-
-    /**
-     * 
-     */
     private static final long            serialVersionUID = 1L;
 
     private ArrayList<DFUDataColumnInfo> columns;
@@ -244,18 +237,18 @@ public class DFUFileDetailInfo extends DFUFileDetail
     /**
      * @return the true FileType for this file, based on complex logic.
      */
-    public FileType getFileType()
+    public FileFormat getFileType()
     {
-
         if (this.getName() == null)
         {
-            return FileType.UNKNOWN;
+            return FileFormat.UNKNOWN;
         }
 
         // thor files store filetype in content type
         boolean hasxpath = hasEcl() && getEcl().toLowerCase().contains("xpath");
 
-        if ("flat".equalsIgnoreCase(getContentType()))
+        FileFormat fileFormatFromContent = FileFormat.getFileFormat(getContentType());
+        if (fileFormatFromContent == FileFormat.FLAT)
         {
 
             // CSVs created by HPCC have file data; sprayed csvs return only
@@ -263,24 +256,26 @@ public class DFUFileDetailInfo extends DFUFileDetail
             // in the record definition in the ecl attribute of dfu file info.
             if (!hasEcl() && this.isSprayedCsv())
             {
-                return FileType.CSV;
+                return FileFormat.CSV;
             }
 
-            return FileType.FLAT;
+            return FileFormat.FLAT;
         }
-        else if ("key".equalsIgnoreCase(getContentType()))
+        else if (fileFormatFromContent == FileFormat.KEYED)
         {
-            return FileType.INDEX;
+            return FileFormat.KEYED;
         }
-        else if (getContentType() == null || getContentType().equals(""))
+        //else if (getContentType() == null || getContentType().equals(""))
+        else if (fileFormatFromContent == null)
         {
-            if (FileType.CSV.toString().equalsIgnoreCase(getFormat()))
+            FileFormat fileFormat = FileFormat.getFileFormat(getFormat());
+            if (FileFormat.CSV == fileFormat)
             {
-                return FileType.CSV;
+                return FileFormat.CSV;
             }
-            else if (FileType.XML.toString().equalsIgnoreCase(getFormat()))
+            else if (FileFormat.XML == fileFormat)
             {
-                return FileType.XML;
+                return FileFormat.XML;
             }
             // csvs loaded as ascii get a format of "csv", csvs loaded as
             // utf-8 get a format of "utf8"
@@ -288,31 +283,31 @@ public class DFUFileDetailInfo extends DFUFileDetail
             {
                 if (hasxpath)
                 {
-                    return FileType.XML;
+                    return FileFormat.XML;
                 }
                 else
                 {
-                    return FileType.CSV;
+                    return FileFormat.CSV;
                 }
             }
-            else if ((getFormat() == null || getFormat().equals("")) && hasxpath)
+            else if (fileFormat == null && hasxpath)
             {
                 // some HPCC-generated xml files use neither, check ecl
                 // record for xpath
-                return FileType.XML;
+                return FileFormat.XML;
             }
             else if (hasEcl())
             {
-                return FileType.FLAT;
+                return FileFormat.FLAT;
             }
             else
             {
-                return FileType.UNKNOWN;
+                return FileFormat.UNKNOWN;
             }
         }
         else
         {
-            return FileType.UNKNOWN;
+            return FileFormat.UNKNOWN;
         }
     }
 
@@ -341,8 +336,8 @@ public class DFUFileDetailInfo extends DFUFileDetail
      */
     public ArrayList<DFUDataColumnInfo> deduceFields() throws Exception
     {
-
-        if (FileType.FLAT.equals(getFileType()) || FileType.INDEX.equals(getFileType()))
+        FileFormat fileType = getFileType();
+        if (fileType == FileFormat.FLAT || fileType == FileFormat.KEYED)
         {
             // until dfu metadata returns child dataset record structure,
             // need to parse it from the ecl
@@ -355,7 +350,7 @@ public class DFUFileDetailInfo extends DFUFileDetail
             // service yet
             return getColumns();
         }
-        else if (FileType.XML.equals(getFileType()))
+        else if (fileType == FileFormat.XML)
         {
             if (hasEcl() && getColumns().size() == 0)
             {
@@ -363,7 +358,7 @@ public class DFUFileDetailInfo extends DFUFileDetail
             }
             return getColumns();
         }
-        else if (FileType.CSV.equals(getFileType()))
+        else if (fileType == FileFormat.CSV)
         {
             // for csvs generated by thor, return columns retrieved from getDFUMetadata if they exist
             if (getColumns().size() > 0 && !isSprayedCsv())
@@ -420,7 +415,7 @@ public class DFUFileDetailInfo extends DFUFileDetail
      */
     public static ArrayList<DFUDataColumnInfo> GetRecordFromECL(String eclRecordDefinition) throws Exception
     {
-        String tempdef = null;
+        //String tempd..XZFCszdFZFASDFef = null;
         ArrayList<DFUDataColumnInfo> cols = new ArrayList<DFUDataColumnInfo>();
         eclRecordDefinition = eclRecordDefinition.replaceAll("(;|,|RECORD|\\{|\\})", "\n");
         eclRecordDefinition = eclRecordDefinition.replaceAll("RECORD", "RECORD\n");
@@ -439,7 +434,7 @@ public class DFUFileDetailInfo extends DFUFileDetail
             }
             else if (thisline.endsWith(":="))
             {
-                tempdef = thisline.replace(":=", "");
+            //    tempdef = thisline.replace(":=", "");
                 continue;
             }
             // TODO: handle xml field definitions
@@ -473,10 +468,10 @@ public class DFUFileDetailInfo extends DFUFileDetail
      */
     public boolean isSprayedCsv()
     {
-        if ("line".equals(getColumns().get(0).getColumnLabel()) && getColumns().size() != 2)
-        {
-            int i = 0;
-        }
+        //if ("line".equals(getColumns().get(0).getColumnLabel()) && getColumns().size() != 2)
+       // {
+       //     int i = 0;
+       // }
         return getColumns() != null && getColumns().size() == 2 && "line".equals(getColumns().get(0).getColumnLabel());
     }
 
@@ -494,7 +489,7 @@ public class DFUFileDetailInfo extends DFUFileDetail
      */
     public boolean isFirstRowValidFieldNames()
     {
-        if (!FileType.CSV.equals(getFileType()))
+        if (FileFormat.CSV != getFileType())
         {
             return false;
         }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/utils/FileFormat.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/utils/FileFormat.java
@@ -46,9 +46,6 @@ public enum FileFormat
 
     public static FileFormat getFileFormat(String name)
     {
-        if (name == null || name.length() == 0)
-            return null;
-
         String upperName = name.toUpperCase();
         if (mapFileFormatName.containsKey(upperName))
             return mapFileFormatName.get(upperName);

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/utils/FileFormat.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/utils/FileFormat.java
@@ -4,51 +4,55 @@ import java.util.HashMap;
 
 public enum FileFormat
 {
-    DFUff_fixed(0),
-    DFUff_csv(1),
-    DFUff_ascii(1),
-    DFUff_utf8(2),
-    DFUff_utf8n(3),
-    DFUff_utf16(4),
-    DFUff_utf16le(5),
-    DFUff_utf16be(6),
-    DFUff_utf32(7),
-    DFUff_utf32le(8),
-    DFUff_utf32be(9),
-    DFUff_variable(10),
-    DFUff_recfmvb(11),
-    DFUff_recfmv(12),
-    DFUff_variablebigendian(13);
+    UNKNOWN,
+    FLAT,
+    CSV,
+    XML,
+    JSON,
+    KEYED;
 
-    private final int id;
-    FileFormat(int id) { this.id = id; }
-    public int getValue() { return id; }
-
-    private final static HashMap<String, FileFormat> mapDFUFileFormatNameCode = new HashMap<String, FileFormat>();
+    private final static HashMap<FileFormat, String> mapFileFormat2Name = new HashMap<FileFormat, String>();
     static
     {
-        mapDFUFileFormatNameCode.put("csv",                FileFormat.DFUff_csv);
-        mapDFUFileFormatNameCode.put("ascii",              FileFormat.DFUff_ascii);
-        mapDFUFileFormatNameCode.put("utf8",               FileFormat.DFUff_utf8);
-        mapDFUFileFormatNameCode.put("utf16",              FileFormat.DFUff_utf16);
-        mapDFUFileFormatNameCode.put("utf16le",            FileFormat.DFUff_utf16le);
-        mapDFUFileFormatNameCode.put("utf16be",            FileFormat.DFUff_utf16be);
-        mapDFUFileFormatNameCode.put("utf32",              FileFormat.DFUff_utf32);
-        mapDFUFileFormatNameCode.put("utf32le",            FileFormat.DFUff_utf32le);
-        mapDFUFileFormatNameCode.put("utf32be",            FileFormat.DFUff_utf32be);
-        mapDFUFileFormatNameCode.put("variable",           FileFormat.DFUff_variable);
-        mapDFUFileFormatNameCode.put("recfmvb",            FileFormat.DFUff_recfmvb);
-        mapDFUFileFormatNameCode.put("recfmv",             FileFormat.DFUff_recfmv);
-        mapDFUFileFormatNameCode.put("variablebigendian",  FileFormat.DFUff_variablebigendian);
-        mapDFUFileFormatNameCode.put("fixed",              FileFormat.DFUff_fixed);
+        mapFileFormat2Name.put(FLAT,       "FLAT");
+        mapFileFormat2Name.put(CSV,        "CSV");
+        mapFileFormat2Name.put(XML,        "XML");
+        mapFileFormat2Name.put(JSON,       "JSON");
+        mapFileFormat2Name.put(KEYED,      "KEYED");
     }
 
-    public static FileFormat convertDFUFileFormatName2Code(String fileformat)
+    public static String getFileFormatName(FileFormat fileformat)
     {
-        String lower = fileformat.toLowerCase();
-        if(mapDFUFileFormatNameCode.containsKey(lower))
-            return mapDFUFileFormatNameCode.get(lower);
+        if(mapFileFormat2Name.containsKey(fileformat))
+            return mapFileFormat2Name.get(fileformat);
         else
-            return FileFormat.DFUff_fixed;
+            return null;
+    }
+
+    private final static HashMap<String, FileFormat> mapFileFormatName = new HashMap<String, FileFormat>();
+    static
+    {
+       mapFileFormatName.put("FLAT",     FLAT);
+       mapFileFormatName.put("THOR",     FLAT);
+       mapFileFormatName.put("FIXED",    FLAT);
+       mapFileFormatName.put("CSV",      CSV);
+       mapFileFormatName.put("VARIABLE", CSV);
+       mapFileFormatName.put("XML",      XML);
+       mapFileFormatName.put("JSON",     JSON);
+       mapFileFormatName.put("KEYED",    KEYED);
+       mapFileFormatName.put("KEY",      KEYED);
+       mapFileFormatName.put("INDEX",    KEYED);
+    }
+
+    public static FileFormat getFileFormat(String name)
+    {
+        if (name == null || name.length() == 0)
+            return null;
+
+        String upperName = name.toUpperCase();
+        if (mapFileFormatName.containsKey(upperName))
+            return mapFileFormatName.get(upperName);
+        else
+            return FileFormat.UNKNOWN;
     }
 }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/platform/test/PlatformTester.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/platform/test/PlatformTester.java
@@ -64,7 +64,7 @@ public class PlatformTester
             //pick one of the valid clusters
             connector.sprayFlatHPCCFile("shortpersons", "mythor::shortpersons", 155, clusters.get(0) /*myroxie, mythor, etc*/, true);
 
-            System.out.println(FileFormat.convertDFUFileFormatName2Code("xcsv").getValue());
+            System.out.println(FileFormat.getFileFormatName(Utils.findEnumValFromString(FileFormat.class, "CSV")));
             connector.sprayDefaultCSVHPCCFile("shortaccounts","mythor::shortaccounts", clusters.get(0), true);
 
             String outputCSVfileContentsEcl = "Layout_CSV_Accounts := RECORD" +


### PR DESCRIPTION
- move "sprayvariable" format enum to spray client code
- create new fileformat enum and helper w/ flat,csv,xml,json
- add sample use in test code

Signed-off-by: rpastrana <rodrigo.pastrana@lexisnexis.com>