### PR TITLE
JAPI-5 Added feature to allow user defined ecl file for stats

### DIFF
--- a/rdf2hpcc/pom.xml
+++ b/rdf2hpcc/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>org.hpccsystems.hpccjapi</groupId>
       <artifactId>wsclient</artifactId>
-      <version>0.6.0</version>
+      <version>0.6.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>


### PR DESCRIPTION
* Updated POM to require wsclient 0.6.2 for utils.Connection fix
* Added -eclstatsfile flag to allow for user defined ecl
* Hard-coded STATSECL is still default for reporting
* Fixed issue with required parameters not actually being required, and
causing null ptr exceptions later on in the import phase of rdf2hpcc

Signed-off-by: Michael Gardner <michael.gardner@lexisnexis.com>