### PR TITLE
Filter to actual errors

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClient.java
@@ -899,7 +899,15 @@ public class HPCCWsWorkUnitsClient extends DataSingleton
             if (createdWU.getExceptions() == null 
             		&& res.getWorkunit() != null 
             		&& res.getWorkunit().getExceptions() != null) {
-            	this.throwWUECLExceptions(res.getWorkunit().getExceptions(),"Workunit Compile Failed");
+            	int actualerrors=0;
+            	for (int i=0; i < res.getWorkunit().getExceptions().length;i++) {
+            		if ("error".equalsIgnoreCase(res.getWorkunit().getExceptions()[i].getSeverity())) {
+            			actualerrors++;
+            		}
+            	}
+            	if (actualerrors>0) {
+            		this.throwWUECLExceptions(res.getWorkunit().getExceptions(),"Workunit Compile Failed");
+            	}
             } 
         }
         return createdWU;


### PR DESCRIPTION
Don't fail if only warnings exist in the Workunit eclexceptions collection.

For https://track.hpccsystems.com/browse/JAPI-44
