### PR TITLE
JAPI-50 Fixed Null Ptr Exception in DFUFileDetailInfo

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
@@ -303,7 +303,7 @@ public class DFUFileDetailInfo extends DFUFileDetail
             }
             // csvs loaded as ascii get a format of "csv", csvs loaded as
             // utf-8 get a format of "utf8"
-            if (getFormat().toLowerCase().startsWith("utf"))
+            if (getFormat() != null && getFormat().toLowerCase().startsWith("utf"))
             {
                 if (hasxpath)
                 {


### PR DESCRIPTION
@rpastrana I reviewed all the other possible issues in this file.  This is the one change that was necessary to fix the null ptr exception without screwing up the logic.  The way we discussed earlier isn't possible because the file type can still be null and we can derive the file type from other attributes that are set.

Signed-off-by: Michael Gardner <michael.gardner@lexisnexis.com>