### PR TITLE
issue #54 enhanced annotations

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/EclRecord.g4
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/EclRecord.g4
@@ -40,14 +40,14 @@ record_def_inline:
 ;
 
 record_def:
-    REC_SYM (COMMA maxlength)? eclfield_decl SEMI comment? (eclfield_decl SEMI comment?)* END_SYM SEMI
+    REC_SYM (COMMA maxlength)? comment? eclfield_decl SEMI comment? (eclfield_decl SEMI comment?)* END_SYM SEMI
 ;
 defined_record_def :
     TOKEN ASSING_SYM (record_def|record_def_inline)
 ;
 
 exploded_dataset_record_def:
-    REC_SYM (COMMA maxlength)? eclfield_decl SEMI comment? (eclfield_decl SEMI comment?)* END_SYM
+    REC_SYM (COMMA maxlength)? comment? eclfield_decl SEMI comment? (eclfield_decl SEMI comment?)* END_SYM
 ;
 
 inline_dataset_record_def:
@@ -59,6 +59,7 @@ record_defs:
     | record_def
     | defined_record_def
 ;
+
 
 nested_dataset_decl: 'DATASET' '(' TOKEN ')' (TOKEN|UTOKEN) ('{' opts '}')?; 
 
@@ -99,11 +100,11 @@ xmldefaultval:
 annotation_name : ATOKEN;
 annotation_param : (TOKEN|UTOKEN);
 annotation_arguments : annotation_param (COMMA annotation_param)*;
-annotation : annotation_name OPAREN annotation_arguments CPAREN;
+annotation : annotation_name ( OPAREN annotation_arguments CPAREN )?;
 
 comment:
-	( '//' annotation? .*? ) |
-	( '/*' annotation? .*? (.*?'*/' | '*/'))
+	( '//' annotation?  (COMMA annotation)* .*? ) |
+	( '/*' annotation?  (COMMA annotation)* .*? (.*?'*/' | '*/'))
 ;
 
 OPAREN             : '(';

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/EclRecordReader.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/EclRecordReader.java
@@ -445,6 +445,8 @@ public class EclRecordReader extends EclRecordBaseListener
         if (currentrec.getChildColumns().size() > 0) {
             final DFUDataColumnInfo info = currentrec.getChildColumns().get(currentrec.getChildColumns().size() - 1);
             info.getAnnotations().add(new DFUDataColumnAnnotation(annotationName, annotationParams));
+        } else {
+        	currentrec.getAnnotations().add(new DFUDataColumnAnnotation(annotationName,annotationParams));
         }
     }
 
@@ -469,6 +471,6 @@ public class EclRecordReader extends EclRecordBaseListener
     public void enterAnnotation(final EclRecordParser.AnnotationContext ctx) {
         super.enterAnnotation(ctx);
         annotationName = null;
-        annotationParams.clear();
+        annotationParams=new ArrayList<String>();
     }
 }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUDataColumnAnnotation.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUDataColumnAnnotation.java
@@ -1,5 +1,6 @@
 package org.hpccsystems.ws.client.platform;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class DFUDataColumnAnnotation {
@@ -18,5 +19,11 @@ public class DFUDataColumnAnnotation {
 
     public List<String> getParameters() {
         return parameters;
+    }
+    public String toString() {
+    	StringBuffer sb=new StringBuffer();
+    	sb.append("name:").append(String.valueOf(name));
+    	sb.append(" parameters:").append(Arrays.toString(parameters.toArray()));
+    	return sb.toString();
     }
 }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUDataColumnInfo.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUDataColumnInfo.java
@@ -56,6 +56,12 @@ public class DFUDataColumnInfo extends DFUDataColumn
         sb.append("\tMaxcount:").append(this.getMaxcount()).append("\n");
         sb.append("\txpath:").append(this.getXpath()).append("\n");
         sb.append("\txmldefault:").append(this.getXmlDefaultVal()).append("\n");
+        if (this.getAnnotations() != null && this.getAnnotations().size()>0) {
+        	sb.append("annotations:");
+        	for (DFUDataColumnAnnotation a:this.getAnnotations()) {
+        		sb.append(a.toString());
+        	}
+        }
         for (DFUDataColumnInfo col : this.getChildColumns())
         {
             sb.append("\n\t").append(col.getColumnLabel()).append(":").append(col.toString());


### PR DESCRIPTION
Fixes https://track.hpccsystems.com/browse/JAPI-54

* Support annotations with no parameters, e.g. // @FEW
* Support multiple annotations per field, e.g. // @FEW, @METATYPE(SSN)
* Support annotations for Records, e.g. RECORD //@RECORDCOUNT(100000000)
* Add annotations to toString() method
* Add tests for the above to DFUFileDetailInfoTest and run test

I built the wsclient jar and ran the HIPIE junit tests for metatype annotations to confirm everything still works.