### PR TITLE
JAPI-00083: StateID from State only.

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClient.java
@@ -382,7 +382,7 @@ public class HPCCWsWorkUnitsClient extends DataSingleton
         if (wu != null) {
             if (wu.getStateID() != null) {
                 return getStateID(wu.getStateID());
-            } else if (wu.getState() != null && wu.getState().trim().length() != 0) {
+            } else if (wu.getState() != null) {
                 return Workunit.translateWUState(wu.getState());
             }
         }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClient.java
@@ -56,6 +56,7 @@ import org.hpccsystems.ws.client.gen.wsworkunits.v1_62.WsWorkunitsServiceSoap;
 import org.hpccsystems.ws.client.gen.wsworkunits.v1_62.WsWorkunitsServiceSoapProxy;
 import org.hpccsystems.ws.client.gen.wsworkunits.v1_62.ThorLogInfo;
 import org.hpccsystems.ws.client.platform.WUState;
+import org.hpccsystems.ws.client.platform.Workunit;
 import org.hpccsystems.ws.client.platform.WorkunitInfo;
 import org.hpccsystems.ws.client.platform.Version;
 import org.hpccsystems.ws.client.utils.Connection;
@@ -378,10 +379,15 @@ public class HPCCWsWorkUnitsClient extends DataSingleton
      */
     public static WUState getStateID(WorkunitInfo wu)
     {
-        if (wu != null)
-            return getStateID(wu.getStateID());
-        else
-            return WUState.UNKNOWN;
+        if (wu != null) {
+            if (wu.getStateID() != null) {
+                return getStateID(wu.getStateID());
+            } else if (wu.getState() != null && wu.getState().trim().length() != 0) {
+                return Workunit.translateWUState(wu.getState());
+            }
+        }
+
+        return WUState.UNKNOWN;
     }
 
     /**

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/Workunit.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/Workunit.java
@@ -156,7 +156,7 @@ public class Workunit extends DataSingleton
         return WUState.UNKNOWN;
     }
 
-    public static boolean isFailedState(String state) throws Exception
+    public static boolean isFailedState(String state)
     {
         WUState statecode = translateWUState(state);
         switch (statecode)

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/Workunit.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/Workunit.java
@@ -192,11 +192,8 @@ public class Workunit extends DataSingleton
             WuStateNameMap.put("RUNNING", WUState.RUNNING);
     }
 
-    public static WUState translateWUState(String state) throws Exception
+    public static WUState translateWUState(String state)
     {
-        if (WuStateNameMap.size() <= 0)
-            throw new Exception("WUStates were not loaded, cannot translate");
-
         if (WuStateNameMap.containsKey((state.toUpperCase())))
                 return WuStateNameMap.get(state.toUpperCase());
         else

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClientTest.java
@@ -11,27 +11,34 @@ import static org.junit.Assert.*;
 public class HPCCWsWorkUnitsClientTest {
     @Test
     public void getStateID() throws Exception {
+
+        // Check we get UNKNOWN if neither the id or name are set.
         assertEquals(WUState.UNKNOWN, HPCCWsWorkUnitsClient.getStateID(new WorkunitInfo()));
 
+        // Check that we can determine the WUState when we just set the state name.
         final WorkunitInfo stateOnly = new WorkunitInfo();
         stateOnly.setState(WUState.ARCHIVED.name());
         assertEquals(WUState.ARCHIVED, HPCCWsWorkUnitsClient.getStateID(stateOnly));
 
+        // Check that we can determine the WUState when only the state id is set.
         final WorkunitInfo idOnly = new WorkunitInfo();
         idOnly.setStateID(1);
         assertEquals(WUState.COMPILED, HPCCWsWorkUnitsClient.getStateID(idOnly));
 
+        // Check that we return "UNKNOWN" for state that don't exist.
         final WorkunitInfo bogusName = new WorkunitInfo();
         bogusName.setState("FOO");
         assertEquals(WUState.UNKNOWN, HPCCWsWorkUnitsClient.getStateID(bogusName));
 
-        // Backwards compatible, returns UNKNOWN for null.
+        // Check for backwards compatibility, returns UNKNOWN for null.
         final WorkunitInfo asNull = null;
         assertEquals(WUState.UNKNOWN, HPCCWsWorkUnitsClient.getStateID(asNull));
     }
 
     @Test
     public void isWorkunitComplete() throws Exception {
+        // JAPI-83, if state ID isn't set, we should still be able to determine
+        // isWorkunitComplete without throwing an NPE if we have a NAME.
         final WorkunitInfo stateOnly = new WorkunitInfo();
         stateOnly.setState(WUState.ARCHIVED.name());
         assertTrue(HPCCWsWorkUnitsClient.isWorkunitComplete(stateOnly));

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/HPCCWsWorkUnitsClientTest.java
@@ -1,0 +1,39 @@
+package org.hpccsystems.ws.client;
+
+import org.hpccsystems.ws.client.platform.WUState;
+import org.hpccsystems.ws.client.platform.Workunit;
+import org.hpccsystems.ws.client.platform.WorkunitInfo;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class HPCCWsWorkUnitsClientTest {
+    @Test
+    public void getStateID() throws Exception {
+        assertEquals(WUState.UNKNOWN, HPCCWsWorkUnitsClient.getStateID(new WorkunitInfo()));
+
+        final WorkunitInfo stateOnly = new WorkunitInfo();
+        stateOnly.setState(WUState.ARCHIVED.name());
+        assertEquals(WUState.ARCHIVED, HPCCWsWorkUnitsClient.getStateID(stateOnly));
+
+        final WorkunitInfo idOnly = new WorkunitInfo();
+        idOnly.setStateID(1);
+        assertEquals(WUState.COMPILED, HPCCWsWorkUnitsClient.getStateID(idOnly));
+
+        final WorkunitInfo bogusName = new WorkunitInfo();
+        bogusName.setState("FOO");
+        assertEquals(WUState.UNKNOWN, HPCCWsWorkUnitsClient.getStateID(bogusName));
+
+        // Backwards compatible, returns UNKNOWN for null.
+        final WorkunitInfo asNull = null;
+        assertEquals(WUState.UNKNOWN, HPCCWsWorkUnitsClient.getStateID(asNull));
+    }
+
+    @Test
+    public void isWorkunitComplete() throws Exception {
+        final WorkunitInfo stateOnly = new WorkunitInfo();
+        stateOnly.setState(WUState.ARCHIVED.name());
+        assertTrue(HPCCWsWorkUnitsClient.isWorkunitComplete(stateOnly));
+    }
+}


### PR DESCRIPTION
Perhaps not the best fix, but if for some reason the WS doesn’t return the state ID, but does return the state name, allow these methods to work and not throw an NPE.  This previously happened when checking an archived work unit.

I also considered setting the ID during the copy() method of WorkUnitInfo but then the state of the object wouldn't represent the true response.

<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [X] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
   - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [X] The change has been fully tested:
  - [X] I have performed unit tests to cover my changes.
  - [ ] I have performed system test and covered possible regressions and side effects.
  - [X] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->
Via the attached JUnit tests.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
