### PR TITLE
japi-107 - update antlr grammar to handle ecl fields named maxlength

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/EclRecord.g4
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/EclRecord.g4
@@ -29,7 +29,7 @@ eclfield_type:
 ;
 
 eclfield_name:
-    UTOKEN | TOKEN
+    UTOKEN | TOKEN | 'MAXLENGTH' | 'maxlength'
 ;
 eclfield_recref:
     OPAREN TOKEN CPAREN

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfoTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfoTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertNotNull;
 public class DFUFileDetailInfoTest {
 
     private final String WITH_ANNOTATION = "RECORD\nSTRING SSN; // @METATYPE(SSN)\nEND;";
+    private final String MAXLENGTH = "RECORD\nSTRING SSN;\nINTEGER8 maxlength;\nEND;";
     private final String WITH_ANNOTATION_NO_PARAMS = "RECORD\nSTRING SSN; // @FEW\nEND;";
     private final String WITH_ANNOTATION_AND_COMMENT = "RECORD\nSTRING SSN; // @FOO(BAR) foo equals kittens, bar equals cats\nEND;";
     private final String WITH_ANNOTATION_MULTI_PARAMS = "RECORD\nSTRING SSN; // @FOO(BAR1, BAR2,BAR3)\nEND;";
@@ -217,5 +218,16 @@ public class DFUFileDetailInfoTest {
         assertEquals("FOO",annotation.getName());
         assertEquals(1,annotation.getParameters().size());
         assertEquals("BAR",annotation.getParameters().get(0));
+    }
+    
+    
+    @Test
+    public void testGetRecordMaxlength() throws Exception {
+        EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(MAXLENGTH);
+        DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
+        assertNotNull(recordDefInfo);
+        assertEquals(0, recordDefInfo.getAnnotations().size());
+        DFUDataColumnInfo column = getColumnByName(recordDefInfo, "maxlength");
+        assertNotNull(column);
     }
 }


### PR DESCRIPTION
Updated the antlr grammar for ecl record parsing, and added a unit test to test the change.  All unit tests for record parsing still work.

Also tested via HIPIE to verify that the original issue (reading in salt record layouts containing maxlength fields) was resolved.
<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [x] I have created a corresponding JIRA ticket for this submission
- [x] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [x] The change has been fully tested:
  - [x] I have performed unit tests to cover my changes.
  - [x] I have performed system test and covered possible regressions and side effects.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
