### PR TITLE
JAPI-114: fix ecl parsing

### DIFF
--- a/wsclient/pom.xml
+++ b/wsclient/pom.xml
@@ -160,7 +160,7 @@
 						<includes>
 							<include>**/*.class</include>
 						</includes>
-						<excludedGroups>org.hpccsystems.ws.client.IntegrationTest</excludedGroups>
+						<excludedGroups>org.hpccsystems.ws.client.IntegrationTest,org.hpccsystems.ws.client.ManualUnitTest</excludedGroups>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/EclRecord.g4
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/EclRecord.g4
@@ -21,11 +21,12 @@ eclfield_decl:
      (eclfield_type eclfield_name (OCURLY opts CCURLY)?
      | nested_dataset_decl
      | nested_inline_dataset_decl
+     | (inline_dataset_record_def eclfield_name)
      | eclfield_recref)
 ;
 
 eclfield_type:
-    ('SET OF'|'set of')? TOKEN
+    ('SET OF'|'set of')? (UTOKEN|TOKEN)
 ;
 
 eclfield_name:
@@ -36,14 +37,14 @@ eclfield_recref:
 ;
 
 record_def_inline:
-    OCURLY eclfield_decl ((COMMA)* eclfield_decl)* CCURLY SEMI
+    OCURLY (COMMA maxlength)? eclfield_decl ((COMMA)* eclfield_decl)* CCURLY SEMI
 ;
 
 record_def:
     REC_SYM (COMMA maxlength)? comment? eclfield_decl SEMI comment? (eclfield_decl SEMI comment?)* END_SYM SEMI
 ;
 defined_record_def :
-    TOKEN ASSING_SYM (record_def|record_def_inline)
+    (UTOKEN|TOKEN) ASSING_SYM (record_def|record_def_inline)
 ;
 
 exploded_dataset_record_def:
@@ -61,7 +62,7 @@ record_defs:
 ;
 
 
-nested_dataset_decl: 'DATASET' '(' TOKEN ')' (TOKEN|UTOKEN) ('{' opts '}')?; 
+nested_dataset_decl: 'DATASET' '(' (UTOKEN|TOKEN) ')' (TOKEN|UTOKEN) ('{' opts '}')?; 
 
 nested_inline_dataset_decl:
      DATASET_SYM OPAREN (exploded_dataset_record_def|inline_dataset_record_def) CPAREN (TOKEN|UTOKEN) (OCURLY opts CCURLY)?
@@ -77,10 +78,14 @@ opt:
     | defaultval
     | xpath
     | xmldefaultval
+    | blob
 ;
 maxlength:
-    'MAXLENGTH' OPAREN INT CPAREN
+    ('MAXLENGTH' OPAREN INT CPAREN | 'maxlength' OPAREN INT CPAREN | 'maxLength' OPAREN INT CPAREN)
 ;
+
+blob: ('BLOB' | 'blob');
+
 maxcount:
     'MAXCOUNT' OPAREN INT CPAREN
 ;
@@ -126,5 +131,6 @@ fragment ESCAPED_QUOTE : '\\\'';
 STRING :   '\'' ( ESCAPED_QUOTE | ~('\'') )* '\'';
 ATOKEN: [@][a-zA-Z0-9_-]+[a-zA-Z0-9_];
 TOKEN :  ~[_\r\n\t; (),:={}-]~[\r\n \t;(),:={}-]* ;
-UTOKEN: [_][a-zA-Z0-9_-]+[a-zA-Z0-9_];
+UTOKEN: [_]+[a-zA-Z0-9_-]+[a-zA-Z0-9_];
 ECL_NUMBERED_TYPE: TOKEN INT?;
+

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/EclRecordReader.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/EclRecordReader.java
@@ -215,6 +215,21 @@ public class EclRecordReader extends EclRecordBaseListener
      * {@inheritDoc}
      *
      * <p>
+     * if a MAXCOUNT option is encountered, add it to the current field/record being processed
+     * </p>
+     */
+    @Override
+    public void enterBlob(EclRecordParser.BlobContext ctx)
+    {
+        if (currentfield != null)
+        {
+            currentfield.setBlob(true);
+        }
+    }
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
      * When entering a child dataset definition in a RECORD layout, (field1:=DATASET(l_rec);) 
      * look for an exiting record layout
      * matching the dataset type of the child dataset and add its fields as child fields of

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/ErrorListener.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/ErrorListener.java
@@ -1,5 +1,8 @@
 package org.hpccsystems.ws.client.antlr;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.FailedPredicateException;
 import org.antlr.v4.runtime.InputMismatchException;
@@ -17,6 +20,7 @@ public class ErrorListener extends BaseErrorListener
 
     private EclRecordReader     parent;
     private ErrorStrategy errorHandler = new ErrorStrategy();
+    List<String> errors=new ArrayList<String>();
 
     // *************************************************************
     // * Attaching to a parser or lexer
@@ -24,6 +28,7 @@ public class ErrorListener extends BaseErrorListener
 
     public void attach(Parser parser)
     {
+        errors.clear();
         parser.removeErrorListeners();
         parser.addErrorListener(this);
         parser.setErrorHandler(errorHandler);
@@ -45,52 +50,58 @@ public class ErrorListener extends BaseErrorListener
     {
         if (e != null)
         {
-            msg = getErrorMessage(recognizer, e);
+            msg = getErrorMessage(recognizer, e,line,charPositionInLine,offendingSymbol);
         }
-
-        System.err.println(msg);
-
+        
+        errors.add(msg);
     }
 
+    public List<String> getErrors() {
+        return errors;
+    }
     public void setParent(EclRecordReader r)
     {
         this.parent = r;
     }
 
-    private String getErrorMessage(Recognizer<?, ?> recognizer, RecognitionException e)
+    private String getErrorMessage(Recognizer<?, ?> recognizer, RecognitionException e, int line, int charPositionInLine, Object offendingSymbol)
     {
-        String msg = "GENERAL_PARSE_ERROR";
-        String loc = "";
-        if (e.getOffendingToken() != null)
-        {
-            loc = "(" + e.getOffendingToken().getLine() + "," + e.getOffendingToken().getCharPositionInLine() + "-"
-                    + e.getOffendingToken().getCharPositionInLine()
-                    + (e.getOffendingToken().getStopIndex() - e.getOffendingToken().getStartIndex()) + ")";
-        }
+        StringBuilder msgstr=new StringBuilder();
+       
         if (e instanceof InputMismatchException)
         {
             InputMismatchException ime = (InputMismatchException) e;
             String expected = ime.getExpectedTokens().toString(recognizer.getVocabulary());
-            msg = "MISMATCHED_TOKEN " + e.getOffendingToken().getText() + " , expected one of " + expected;
+            msgstr.append("MISMATCHED_TOKEN ").append(e.getOffendingToken().getText()).append(" , expected one of ").append(expected);
         }
         else if (e instanceof NoViableAltException)
         {
-            msg = "NO_PARSE_ALTERNATIVE," + getTokenErrorDisplay(e.getOffendingToken());
+            msgstr.append("NO_PARSE_ALTERNATIVE,").append(getTokenErrorDisplay(e.getOffendingToken()));
         }
         else if (e instanceof LexerNoViableAltException)
         {
-            msg = "NO_PARSE_ALTERNATIVE," + getTokenErrorDisplay(e.getOffendingToken());
+            msgstr.append("NO_PARSE_ALTERNATIVE,").append(getTokenErrorDisplay(e.getOffendingToken()));
         }
         else if (e instanceof FailedPredicateException)
         {
             FailedPredicateException fpe = (FailedPredicateException) e;
-            msg = "FAILED_PARSE_PREDICATE," + recognizer.getRuleNames()[fpe.getRuleIndex()] + "," + fpe.getPredicate();
+            msgstr.append("FAILED_PARSE_PREDICATE,").append(recognizer.getRuleNames()[fpe.getRuleIndex()]).append(",").append(fpe.getPredicate());
         }
         else
         {
-            msg = "GENERAL_PARSE_ERROR," + e.getMessage();
+            msgstr.append("GENERAL_PARSE_ERROR,").append(e.getMessage());
         }
-        return msg + loc;
+        StringBuilder loc = new StringBuilder("");
+        if (e.getOffendingToken() != null)
+        {
+            loc.append(" at line ").append( e.getOffendingToken().getLine()).append(", char ").append(e.getOffendingToken().getCharPositionInLine()).append("-")
+                    .append(e.getOffendingToken().getCharPositionInLine())
+                    .append(e.getOffendingToken().getStopIndex() - e.getOffendingToken().getStartIndex()) ;
+            
+        } else {
+            loc.append(" at line ").append(line).append(", char ").append(charPositionInLine);
+        }
+        return msgstr.toString() + loc.toString();        
     }
 
     private String getTokenErrorDisplay(Token t)

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/ErrorStrategy.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/antlr/ErrorStrategy.java
@@ -3,6 +3,7 @@ package org.hpccsystems.ws.client.antlr;
 import java.text.ParseException;
 
 import org.antlr.v4.runtime.DefaultErrorStrategy;
+import org.antlr.v4.runtime.NoViableAltException;
 import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Token;
@@ -14,10 +15,6 @@ public class ErrorStrategy extends DefaultErrorStrategy
     @Override
     protected void reportMissingToken(Parser recognizer)
     {
-        if (inErrorRecoveryMode(recognizer))
-        {
-            return;
-        }
 
         beginErrorCondition(recognizer);
 
@@ -32,6 +29,22 @@ public class ErrorStrategy extends DefaultErrorStrategy
                 + expecting.toString(recognizer.getVocabulary()) + " at " + loc, recognizer, null,
                 recognizer.getContext());
         recognizer.notifyErrorListeners(t, "missing token", e);
+    }
+    
+    @Override
+    protected void reportNoViableAlternative(Parser recognizer, NoViableAltException e) {
+
+        beginErrorCondition(recognizer);
+
+        Token t = recognizer.getCurrentToken();
+        String tokenName = getTokenErrorDisplay(t);
+        IntervalSet expecting = getExpectedTokens(recognizer);
+        String expectingStr = expecting.toString(recognizer.getVocabulary());
+
+        RecognitionException re = new RecognitionException("NO_VIABLE_ALTERNATIVE at " + tokenName + ", expecting "
+                + expecting.toString(recognizer.getVocabulary()), recognizer, null, recognizer.getContext());
+        recognizer.notifyErrorListeners(t, "extra token", e);
+
     }
 
     @Override

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUDataColumnInfo.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUDataColumnInfo.java
@@ -18,6 +18,7 @@ public class DFUDataColumnInfo extends DFUDataColumn
     private String                  xmlDefaultVal    = null;
     private String                  maxcount         = null;
     private String                  maxlength        = null;
+    private boolean                 isblob             = false;
     private List<DFUDataColumnAnnotation> annotations = new ArrayList<DFUDataColumnAnnotation>();
 
     /**
@@ -49,6 +50,7 @@ public class DFUDataColumnInfo extends DFUDataColumn
         sb.append("\tColumnSize:").append(this.getColumnSize()).append("\n");
         sb.append("\tColumnType:").append(this.getColumnType()).append("\n");
         sb.append("\tColumnValue:").append(this.getColumnValue()).append("\n");
+        sb.append("\tIsBlob:").append(this.isBlob()).append("\n");
         sb.append("\tIsKeyedColumn:").append(this.getIsKeyedColumn()).append("\n");
         sb.append("\tIsNaturalColumn:").append(this.getIsNaturalColumn()).append("\n");
         sb.append("\tMaxSize:").append(this.getMaxSize()).append("\n");
@@ -187,5 +189,13 @@ public class DFUDataColumnInfo extends DFUDataColumn
 
     public void setAnnotations(final List<DFUDataColumnAnnotation> annotations) {
         this.annotations = annotations;
+    }
+    
+    public boolean isBlob() {
+        return isblob;
+    }
+
+    public void setBlob(boolean blob) {
+        this.isblob = blob;
     }
 }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfo.java
@@ -622,12 +622,13 @@ public class DFUFileDetailInfo extends DFUFileDetail
         }
         catch (Exception e)
         {
-            System.out.println("Error parsing Record:" + e.getMessage());
+            cr.getErrorHandler().getErrors().add("Error parsing Record:" + e.getMessage());
         }
         if (cr.getEclRecordInfo() != null)
         {
             cr.getEclRecordInfo().setOriginalEcl(content);
         }
+        cr.getEclRecordInfo().setParseErrors(cr.getErrorHandler().getErrors());
         return cr.getEclRecordInfo();
 
     }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFURecordDefInfo.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/DFURecordDefInfo.java
@@ -95,4 +95,13 @@ public class DFURecordDefInfo extends DFUDataColumnInfo
         this.maxreclength = maxreclength;
     }
 
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "DFURecordDefInfo [inline=" + inline + ", recordLayoutName=" + recordLayoutName + ", singlerow="
+                + singlerow + ", maxreclength=" + maxreclength + ", fileType=" + fileType + "]";
+    }
+
 }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/EclRecordInfo.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/EclRecordInfo.java
@@ -1,6 +1,8 @@
 package org.hpccsystems.ws.client.platform;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import org.hpccsystems.ws.client.utils.FileFormat;
 
@@ -8,7 +10,8 @@ public class EclRecordInfo implements java.io.Serializable
 {
 	private static final long serialVersionUID = 7430756413782258252L;
 	private String originalEcl;
-
+	private List<String> parseErrors=new ArrayList<String>();
+	
     public EclRecordInfo()
     {
     }
@@ -68,4 +71,19 @@ public class EclRecordInfo implements java.io.Serializable
             }
         }
     }
+
+    /**
+     * @return the parseErrors
+     */
+    public List<String> getParseErrors() {
+        return parseErrors;
+    }
+
+    /**
+     * @param parseErrors the parseErrors to set
+     */
+    public void setParseErrors(List<String> parseErrors) {
+        this.parseErrors = parseErrors;
+    }
+
 }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfoTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/platform/DFUFileDetailInfoTest.java
@@ -1,9 +1,31 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
 package org.hpccsystems.ws.client.platform;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class DFUFileDetailInfoTest {
 
@@ -21,6 +43,7 @@ public class DFUFileDetailInfoTest {
     private final String ML_WITH_ANNOTATION_LIKE_COMMENT = "RECORD\nSTRING SSN; /* THIS(ISNT) an annotation. */\nEND;";
     private final String ML_INLINE = "RECORD\nSTRING SSN; /* @FOO(BAR) */\nEND;";
     private final String FULL_RECORD = "child := RECORD\n\t\tSTRING name;\nEND;\nRECORD // @LARGE\nSTRING FNAME;\nSTRING LNAME;\nSTRING MNAME;\nSTRING DOB;\nSTRING SSN; // @METATYPE(SSN)\nSTRING ADDR1;\nSTRING ADDR2;\nSTRING CITY;\nSTRING STATE;\nSTRING ZIP; // @METATYPE(ZIP), @FEW, @MULTIPARAMS(PARAM1,PARAM2)\nSTRING DLNUMBER;\nDATASET(child) KIDS;\nEND;";
+    private final String INLINE_WITH_MAXLENGTH = "{ , MAXLENGTH(84) string4 sic4_code, string80 sic4_description };";
 
     public static DFUDataColumnInfo getColumnByName(final DFURecordDefInfo parent, final String name) {
         for (final DFUDataColumnInfo child: parent.getChildColumns()) {
@@ -35,6 +58,9 @@ public class DFUFileDetailInfoTest {
     @Test
     public void testGetRecordEcl() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(WITH_ANNOTATION);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(0, recordDefInfo.getAnnotations().size());
@@ -50,6 +76,9 @@ public class DFUFileDetailInfoTest {
     @Test
     public void testFullRecordEcl() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(FULL_RECORD);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(1, recordDefInfo.getAnnotations().size());
@@ -82,6 +111,9 @@ public class DFUFileDetailInfoTest {
     @Test
     public void testGetRecordEclNoParams() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(WITH_ANNOTATION_NO_PARAMS);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(0, recordDefInfo.getAnnotations().size());
@@ -95,6 +127,9 @@ public class DFUFileDetailInfoTest {
     @Test
     public void testGetRecordEclAnnotationAndComment() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(WITH_ANNOTATION_AND_COMMENT);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(0, recordDefInfo.getAnnotations().size());
@@ -109,6 +144,9 @@ public class DFUFileDetailInfoTest {
     @Test
     public void testGetRecordEclMultiParams() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(WITH_ANNOTATION_MULTI_PARAMS);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(0, recordDefInfo.getAnnotations().size());
@@ -125,6 +163,9 @@ public class DFUFileDetailInfoTest {
     @Test
     public void testGetRecordEclWithComment() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(WITH_COMMENT);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(0, recordDefInfo.getAnnotations().size());
@@ -132,9 +173,26 @@ public class DFUFileDetailInfoTest {
         assertEquals(0, column.getAnnotations().size());
     }
 
+
+    @Test
+    public void testInlineWithMaxlength() throws Exception {
+        EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(INLINE_WITH_MAXLENGTH);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
+        DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
+        assertNotNull(recordDefInfo);
+        assertEquals(0, recordDefInfo.getAnnotations().size());
+        DFUDataColumnInfo column = getColumnByName(recordDefInfo, "sic4_code");
+        assertNotNull(column);
+    }
+
     @Test
     public void testGetRecordEclWithAnnotationLikeComment() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(WITH_ANNOTATION_LIKE_COMMENT);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(0, recordDefInfo.getAnnotations().size());
@@ -146,6 +204,9 @@ public class DFUFileDetailInfoTest {
     @Test
     public void testGetRecordMlEcl() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(ML_WITH_ANNOTATION);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(0, recordDefInfo.getAnnotations().size());
@@ -160,6 +221,9 @@ public class DFUFileDetailInfoTest {
     @Test
     public void testGetRecordMlEclAnnotationAndComment() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(ML_WITH_ANNOTATION_AND_COMMENT);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(0,recordDefInfo.getAnnotations().size());
@@ -173,6 +237,9 @@ public class DFUFileDetailInfoTest {
     @Test
     public void testGetRecordMlEclMultiParams() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(ML_WITH_ANNOTATION_MULTI_PARAMS);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed get multi-annotated recordset:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(0, recordDefInfo.getAnnotations().size());
@@ -189,6 +256,9 @@ public class DFUFileDetailInfoTest {
     @Test
     public void testGetRecordMlEclWithComment() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(ML_WITH_COMMENT);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed get ml with comment test:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(0, recordDefInfo.getAnnotations().size());
@@ -199,6 +269,9 @@ public class DFUFileDetailInfoTest {
     @Test
     public void testGetRecordMlEclWithAnnotationLikeComment() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(ML_WITH_ANNOTATION_LIKE_COMMENT);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed get record with annotation comment:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(0, recordDefInfo.getAnnotations().size());
@@ -209,6 +282,9 @@ public class DFUFileDetailInfoTest {
     @Test
     public void testGetRecordMlEclInlineComment() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(ML_INLINE);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed get ml inline test:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(0, recordDefInfo.getAnnotations().size());
@@ -224,10 +300,35 @@ public class DFUFileDetailInfoTest {
     @Test
     public void testGetRecordMaxlength() throws Exception {
         EclRecordInfo info = DFUFileDetailInfo.getRecordEcl(MAXLENGTH);
+        if (info.getParseErrors().size()!=0) {
+            fail("Failed get maxlength test:" + StringUtils.join(info.getParseErrors(),"\n"));
+        }
         DFURecordDefInfo recordDefInfo = info.getRecordsets().get("unnamed0");
         assertNotNull(recordDefInfo);
         assertEquals(0, recordDefInfo.getAnnotations().size());
         DFUDataColumnInfo column = getColumnByName(recordDefInfo, "maxlength");
         assertNotNull(column);
+    }
+    
+    @Test
+    public void testEclParsing() throws Exception {
+        Map<String,String> layouts=new LinkedHashMap<String,String>();
+        layouts.put("inline record with dataset child", "l_test:=RECORD\nSTRING1 test;\nEND;\n\nRECORD\nSTRING __field1;\n{DATASET(l_test) a} field2;\nEND;");
+        layouts.put("record layout def starting with __", "__errx__ := RECORD,maxlength(2097152)\n  integer8 transaction_time{xpath('_call_latency_ms')};\n END;\n\n{ string fname1, integer8 did, DATASET(__errx__) ds };");
+        layouts.put("record with {blob} in field definition","RECORD\nSTRING data_content{blob,MAXLENGTH(20000)}; \nEND;");
+        layouts.put("inline record def with maxlength","{,maxLength(84)\r\nstring4 sic4_code, string80 sic4_description };");
+        boolean passed=true;
+        for (Entry<String,String> item:layouts.entrySet()) {
+            EclRecordInfo rec=DFUFileDetailInfo.getRecordFromECL(item.getValue());
+            if (rec.getParseErrors().size()!=0) {                
+                System.out.println(item.getKey() + " FAILED:" + StringUtils.join(rec.getParseErrors(),"\n"));
+                passed=false;
+            } else {
+                System.out.println(item.getKey() + " parsed correctly");
+            }
+        }
+        if (!passed) {
+            fail("not all record structures passed");
+        }
     }
 }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/platform/EclParseRegressionTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/platform/EclParseRegressionTest.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ *     HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *******************************************************************************/
+package org.hpccsystems.ws.client.platform;
+
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.hpccsystems.ws.client.HPCCWsDFUClient;
+import org.hpccsystems.ws.client.HPCCWsWorkUnitsClient;
+import org.hpccsystems.ws.client.ManualUnitTest;
+import org.hpccsystems.ws.client.platform.DFUFileDetailInfo;
+import org.hpccsystems.ws.client.platform.DFULogicalFileInfo;
+import org.hpccsystems.ws.client.platform.EclRecordInfo;
+import org.hpccsystems.ws.client.platform.Platform;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+@Category(ManualUnitTest.class)
+public class EclParseRegressionTest  {
+
+    Logger logger=Logger.getLogger(this.getClass().getName());
+
+    boolean reset=true;
+
+    Platform p=null;
+    
+
+    File failedlist=new File("failedrecs.txt");    
+    File testlist=new File("alreadytested.txt");
+    List<String> alreadytested=new ArrayList<String>();
+    List<String> failedrecs=new ArrayList<String>();
+    public String getIP() {
+        return "";
+    }
+    
+    public int getPort() {
+        return 8010;
+    }
+    
+    public String getHttp() {
+        return "http";
+    }
+    public String getUsername() {
+        return "";
+    }
+    
+    public String getPassword() {
+        return "";
+    }
+    
+    public Platform getPlatform() throws Exception
+    {
+        if (p==null) {
+            p=Platform.get(getHttp(),getIP(),getPort(),getUsername(),getPassword());
+        }
+        return p;
+    }
+    
+    public HPCCWsDFUClient getDFUClient() throws Exception {
+        return getPlatform().getWsDfuClient();
+    }
+    
+    public HPCCWsWorkUnitsClient getWorkunitsClient() throws Exception {
+        return getPlatform().getWsWorkunitsClient();
+    }
+    public String getThorClusterName()
+    {
+        return "thor";
+    }
+    
+    public String getRoxieClusterName()
+    {
+        return "roxie";
+    }
+    
+    
+    public String getHthorClusterName()
+    {
+        return "hthor";
+    }
+
+    @Test
+    public void testSingle() throws Exception {
+  //      String fname=".::lrenn:edit-ma-test";
+        String fname="anthem::enc_wpt_edw_provider_thor_superfile";
+        DFUFileDetailInfo info=getDFUClient().getFileDetails(fname, null);
+        EclRecordInfo rec=DFUFileDetailInfo.getRecordFromECL(info.getEcl());
+        if (rec.getParseErrors().size()!=0) {
+            fail(rec.getParseErrors().toString());
+        }
+    }
+    
+  
+    @Test
+    public void testFailedRecs() throws Exception {
+        failedrecs=Files.readAllLines(failedlist.toPath());
+        for (String rec:failedrecs) {
+            String rececl="";
+            try {
+                DFUFileDetailInfo info=getDFUClient().getFileDetails(rec, null);
+                rececl=info.getEcl();
+                if (StringUtils.isEmpty(rececl)) {
+                    throw new Exception("No record ecl for " + rec);
+                }
+            } catch (Exception e) {
+                System.out.println( "Can't retrieve " + rec + ":" + e.getMessage());
+                continue;
+            }
+            try {
+                EclRecordInfo rece=DFUFileDetailInfo.getRecordFromECL(rececl);
+                alreadytested.add(rec);
+                if (rece.getParseErrors().size()!=0) {
+                    throw new Exception("Failed to parse " + rec + ":" + StringUtils.join(rece.getParseErrors(),"\n"));
+                }
+                System.out.println(rec + " parsed fine");
+            } catch (Exception e) {                
+                System.out.println( e.getMessage());
+            }
+         
+        }
+    }
+  @Test
+    public void testRegressionRecordStructures() throws Exception {
+      if (reset) {
+          FileUtils.deleteQuietly(testlist);
+          FileUtils.deleteQuietly(failedlist);
+      }
+      if (testlist.exists() && !reset) {
+          alreadytested=Files.readAllLines(testlist.toPath());
+          failedrecs=Files.readAllLines(failedlist.toPath());
+      }
+      try {
+          testScope("");
+      } finally {
+          Files.write(testlist.toPath(), StringUtils.join(alreadytested,"\r\n").getBytes());
+          Files.write(failedlist.toPath(), StringUtils.join(failedrecs,"\r\n").getBytes());
+      }
+    }
+    
+    private void testScope(String scope) throws Exception {
+        List<DFULogicalFileInfo> files=getDFUClient().getFiles(scope);
+        for (DFULogicalFileInfo file:files) {
+            
+            String fullfilename= file.getIsDirectory()==true?file.getDirectory():file.getFileName();
+            if (!StringUtils.isEmpty(scope) && !fullfilename.startsWith(scope)) {
+                fullfilename=scope + "::" + fullfilename;
+            }
+            if (alreadytested.contains(fullfilename)) {
+                continue;
+            }
+            if (file.getIsSuperfile()) {
+                alreadytested.add(fullfilename);
+            //    continue;
+            }
+            if (file.getFileName().contains("::key::") || file.getFileName().contains("::keys::") || file.getFileName().startsWith("keys::") || file.getFileName().startsWith("key::")) {
+                alreadytested.add(fullfilename);
+                continue;
+            }            
+            if (file.getIsDirectory()) {
+                alreadytested.add(fullfilename);
+                testScope(fullfilename);
+                continue;
+            }
+            String rececl=null;
+            try {
+                DFUFileDetailInfo info=getDFUClient().getFileDetails(fullfilename, null);
+                rececl=info.getEcl();
+                if (StringUtils.isEmpty(rececl)) {
+                    throw new Exception("No record ecl for " + fullfilename);
+                }
+            } catch (Exception e) {
+                System.out.println( "Can't retrieve " + file.getFileName() + ":" + e.getMessage());
+                alreadytested.add(fullfilename);
+                continue;
+            }
+            System.out.println("testing ecl layout for  " + fullfilename );
+
+            try {
+                    EclRecordInfo rec=DFUFileDetailInfo.getRecordFromECL(rececl);
+                    alreadytested.add(fullfilename);
+                    if (rec.getParseErrors().size()!=0) {
+                        throw new Exception("Failed to parse " + fullfilename + ":" + StringUtils.join(rec.getParseErrors(),"\n"));
+                    }
+                } catch (Exception e) {
+                    failedrecs.add(fullfilename);
+                    System.out.println(rececl + "\n" + e.getMessage());
+                }
+             
+        }
+    }
+}

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/platform/RampsDevRegressionTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/platform/RampsDevRegressionTest.java
@@ -1,0 +1,34 @@
+package org.hpccsystems.ws.client.platform;
+
+public class RampsDevRegressionTest extends EclParseRegressionTest {
+
+    @Override
+    public int getPort() {
+        return 8010;
+    }
+
+    @Override
+    public String getHttp() {
+        return "http";
+    }
+    
+    @Override
+    public String getUsername() {
+        return "dleed";
+    }
+
+    @Override
+    public String getPassword() {
+        return System.getenv("hpccpassword");
+    }
+    
+    @Override
+    public String getIP() {
+        return "10.241.100.159";
+    }
+    
+    @Override
+    public void testRegressionRecordStructures() throws Exception {
+        super.testRegressionRecordStructures();
+    }
+}


### PR DESCRIPTION
This fixes the ecl parse issues found in JAPI-114.

As part of the fix I built a regression test that runs against all files on a cluster and parses their record structures. While running this I found a couple more cases of record structures not being handled (layouts and field types starting with "__", and certain nested inline record structures.)

I also added a parseErrors() collection into the EclRecordInfo object generated by the parser to store any parse errors encountered during parsing. This was needed to correctly validate and test the changes.

<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [x] I have created a corresponding JIRA ticket for this submission
- [x] My code follows the code style of this project.
  - [x] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [x] The change has been fully tested:
  - [x] I have performed unit tests to cover my changes.
  - [x] I have performed system test and covered possible regressions and side effects.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.

## Testing:
Expanded DFUFileDetailInfoTest to test for record structures that were previously failing.

I also created a regression test that iterates through all files on a cluster, tests parsing, and logs which files' ecl failed to parse. After my changes I ran the regression test against two different clusters. The only record ecl that failed to parse was record ecl with invalid syntax.

I created a new test category, ManualUnitTest, for the regression test. I excluded it from the pom to make sure it didn't run during install.

I also ran mvn test from the command line.

