### PR TITLE
JAPI-130 Ensure reported filepart and copy indexes are valid

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/wrappers/wsdfu/DFUFileAccessInfoWrapper.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/wrappers/wsdfu/DFUFileAccessInfoWrapper.java
@@ -57,7 +57,14 @@ public class DFUFileAccessInfoWrapper
         DFUFilePartWrapper [] wrappedDFUFileParts = new DFUFilePartWrapper[fileparts.length];
         for (int i = 0; i < fileparts.length; i++)
         {
-            wrappedDFUFileParts[fileparts[i].getPartIndex()] = new DFUFilePartWrapper(fileparts[i], availableLocations);
+            Integer filepartindex = fileparts[i].getPartIndex();
+            if (filepartindex  < 1 || filepartindex > fileparts.length)
+                throw new IndexOutOfBoundsException("Encountered invalid Filepart index: '" + filepartindex + "'");
+
+            if ( wrappedDFUFileParts[filepartindex-1] != null)
+                throw new IndexOutOfBoundsException("Encountered duplicate Filepart copy index: '" + filepartindex + "'");
+
+            wrappedDFUFileParts[filepartindex-1] = new DFUFilePartWrapper(fileparts[i], availableLocations);
         }
         return wrappedDFUFileParts;
     }

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/wrappers/wsdfu/DFUFilePartWrapper.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/wrappers/wsdfu/DFUFilePartWrapper.java
@@ -31,11 +31,17 @@ public class DFUFilePartWrapper
     public DFUFilePartWrapper(DFUFilePart soapdfufilepart, Hashtable<Integer,String> availableLocations)
     {
         partIndex = soapdfufilepart.getPartIndex();
-
         DFUFileCopy[] dfufilecopies = soapdfufilepart.getCopies();
-        for (DFUFileCopy dfuFileCopy : dfufilecopies)
+        wrappedDFUFileCopies = new DFUFileCopyWrapper [dfufilecopies.length];
+        for (int i = 0; i < dfufilecopies.length; i++)
         {
-            wrappedDFUFileCopies[dfuFileCopy.getCopyIndex()] = new DFUFileCopyWrapper(dfuFileCopy, availableLocations.get(dfuFileCopy.getLocationIndex()));
+             Integer copyindex = dfufilecopies[i].getCopyIndex();
+             if (copyindex == null || copyindex  < 1 || copyindex > dfufilecopies.length )
+                 throw new IndexOutOfBoundsException("Encountered invalid Filepart Copy index: '" + copyindex + "'");
+
+             if (wrappedDFUFileCopies[copyindex-1] != null)
+                 throw new IndexOutOfBoundsException("Encountered duplicate Filepart copy index: '" + copyindex + "'");
+             wrappedDFUFileCopies[copyindex-1] = new DFUFileCopyWrapper(dfufilecopies[i], availableLocations.get(dfufilecopies[i].getLocationIndex()));
         }
     }
 


### PR DESCRIPTION
- Accounts for 1based indexes
- Ensures reported indexes are within bounds

Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [x] I have created a corresponding JIRA ticket for this submission
- [x] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [x] The change has been fully tested:
  - [ ] I have performed unit tests to cover my changes.
  - [ ] I have performed system test and covered possible regressions and side effects.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
