### PR TITLE
JAPI-173 DFSClient: Column pruner does not update record size after p…

### DIFF
--- a/commons-hpcc/src/main/java/org/hpccsystems/commons/ecl/FieldDef.java
+++ b/commons-hpcc/src/main/java/org/hpccsystems/commons/ecl/FieldDef.java
@@ -73,6 +73,11 @@ public class FieldDef implements Serializable
         this.fieldType = fieldType;
         this.typeName = typeName;
         this.defs = defs;
+        if (this.defs == null)
+        {
+            this.defs = new FieldDef[0];
+        }
+
         this.srcType = styp;
         this.fixedLength = isFixedLength;
         this.isUnsigned = isUnsigned;
@@ -123,6 +128,15 @@ public class FieldDef implements Serializable
     public HpccSrcType getSourceType()
     {
         return this.srcType;
+    }
+
+    /**
+     * Length of data or minimum length if variable
+     * @param dataLen
+     */
+    public void setDataLen(long dataLen)
+    {
+        this.len = dataLen;
     }
 
     /**
@@ -269,6 +283,11 @@ public class FieldDef implements Serializable
      */
     public void setDefs(FieldDef[] childDefs)
     {
+        if (childDefs == null)
+        {
+            childDefs = new FieldDef[0];
+        }
+
         this.defs = childDefs;
     }
 

--- a/commons-hpcc/src/main/java/org/hpccsystems/commons/ecl/RecordDefinitionTranslator.java
+++ b/commons-hpcc/src/main/java/org/hpccsystems/commons/ecl/RecordDefinitionTranslator.java
@@ -15,6 +15,7 @@ package org.hpccsystems.commons.ecl;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import org.json.JSONObject;
 import org.json.JSONArray;
 
@@ -152,7 +153,8 @@ public class RecordDefinitionTranslator
         }
 
         // Recurse through the tree structure and generate record defintions
-        HashMap<String, String> recordDefinitionMap = new HashMap<String, String>();
+        // LinkedHashMap to retain insertion order
+        HashMap<String, String> recordDefinitionMap = new LinkedHashMap<String, String>();
         String rootRecordName = getEClTypeDefinition(field, recordDefinitionMap);
 
         // Get root record definition and remove it from the map

--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/ColumnPruner.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/ColumnPruner.java
@@ -141,6 +141,7 @@ public class ColumnPruner implements Serializable
 
         FieldDef ret = new FieldDef(originalRD);
         ret.setDefs(selectedFields.toArray(new FieldDef[0]));
+        ret.setDataLen(0);
         if (ret.getNumDefs() == 0)
         {
             throw new Exception("Error pruning record defintion. No fields were selected for field list: " + this.fieldListString);

--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/ColumnPruner.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/ColumnPruner.java
@@ -141,11 +141,13 @@ public class ColumnPruner implements Serializable
 
         FieldDef ret = new FieldDef(originalRD);
         ret.setDefs(selectedFields.toArray(new FieldDef[0]));
-        ret.setDataLen(0);
         if (ret.getNumDefs() == 0)
         {
             throw new Exception("Error pruning record defintion. No fields were selected for field list: " + this.fieldListString);
         }
+
+        // Correct min record length
+        updateRecordMinLength(ret);
 
         return ret;
     }
@@ -191,5 +193,67 @@ public class ColumnPruner implements Serializable
         FieldDef ret = new FieldDef(originalRecordDef);
         ret.setDefs(selectedFields.toArray(new FieldDef[0]));
         return ret;
+    }
+
+    private void updateRecordMinLength(FieldDef recordDef)
+    {
+        for (int i = 0; i < recordDef.getNumDefs(); i++)
+        {
+            FieldDef childDef = recordDef.getDef(i);
+            if (childDef.getFieldType() == FieldType.RECORD)
+            {
+                updateRecordMinLength(childDef);
+            }
+        }
+
+        long minDataLength = getMinLengthInBytes(recordDef);
+        recordDef.setDataLen(minDataLength);
+    }
+
+    private long getMinLengthInBytes(FieldDef def)
+    {
+        switch (def.getFieldType())
+        {
+            case RECORD:
+            {
+                long minDataLength = 0;
+                for (int i = 0; i < def.getNumDefs(); i++)
+                {
+                    FieldDef childDef = def.getDef(i);
+                    minDataLength += getMinLengthInBytes(childDef);
+                }
+                return minDataLength;
+            }
+            case SET:
+            {
+                // Sets include 4 byte integer dataLength and an additional byte
+                return 5;
+            }
+            default:
+            {
+                long dataLength = 0;
+                if (def.isFixed())
+                {
+                    // Var strings can be fixed length
+                    dataLength = def.getDataLen();
+                    if (def.getFieldType() == FieldType.VAR_STRING)
+                    {
+                        dataLength++;
+                    }
+                    
+                    // Unicode datalength is in code points not bytes
+                    if (def.getSourceType().isUTF16())
+                    {
+                        dataLength *= 2;
+                    }
+                }
+                else
+                {
+                    dataLength = 4;
+                }
+                return dataLength;
+            }
+        }
+        
     }
 }

--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/HpccRemoteFileReader.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/HpccRemoteFileReader.java
@@ -48,6 +48,11 @@ public class HpccRemoteFileReader<T> implements Iterator<T>
     public HpccRemoteFileReader(DataPartition dp, FieldDef originalRD, IRecordBuilder recBuilder) throws Exception
     {
         this.originalRecordDef = originalRD;
+        if (this.originalRecordDef == null)
+        {
+            throw new Exception("HpccRemoteFileReader: Original record definition is null.");
+        }
+
         this.dataPartition = dp;
         this.recordBuilder = recBuilder;
 


### PR DESCRIPTION
…runing

- Changed ColumnPruner to set the min record size to zero after pruning.

Signed-off-by: James McMullan <James.McMullan@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [X] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [X] The change has been fully tested:
  - [ ] I have performed unit tests to cover my changes.
  - [ ] I have performed system test and covered possible regressions and side effects.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
