### PR TITLE
JAPI-184: Update HPCCFile to set the projectedrecordlayout when a projectlist is set.

### DIFF
--- a/commons-hpcc/pom.xml
+++ b/commons-hpcc/pom.xml
@@ -85,11 +85,11 @@
             <artifactId>json</artifactId>
             <version>20180813</version>
         </dependency>
-    	<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-api</artifactId>
-    		<version>2.10.0</version>
-		</dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
     </dependencies>
     <profiles>
 	<profile>

--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/HPCCFile.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/HPCCFile.java
@@ -139,7 +139,10 @@ public class HPCCFile implements Serializable
     public HPCCFile setProjectList(String projectList) throws Exception
     {
         this.columnPruner = new ColumnPruner(projectList);
-        this.projectedRecordDefinition = this.columnPruner.pruneRecordDefinition(this.recordDefinition);
+        if (this.recordDefinition != null) 
+        {
+            this.projectedRecordDefinition = this.columnPruner.pruneRecordDefinition(this.recordDefinition);
+        }
         return this;
     }
 

--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/HPCCFile.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/HPCCFile.java
@@ -134,10 +134,12 @@ public class HPCCFile implements Serializable
 
     /**
      * @param projectList
+     * @throws Exception 
      */
-    public HPCCFile setProjectList(String projectList)
+    public HPCCFile setProjectList(String projectList) throws Exception
     {
         this.columnPruner = new ColumnPruner(projectList);
+        this.projectedRecordDefinition = this.columnPruner.pruneRecordDefinition(this.recordDefinition);
         return this;
     }
 

--- a/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
+++ b/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
@@ -47,10 +47,12 @@ import org.junit.Test;
 
 public class DFSReadWriteTest
 {
-
-    private static final String   clusterIP      = "10.173.147.1";
-    private static final String[] datasets       = { "~demo::salesdata" };
-    private static final int[]    expectedCounts = { 3730};
+    private static final String   clusterIP      = "192.168.56.101";
+    private static final String[] datasets       = { "~benchmark::integer::20kb", "~demo::example_dataset" };
+    private static final int[]    expectedCounts = { 1250, 6 };
+    //private static final String   clusterIP      = "10.173.147.1";
+    //private static final String[] datasets       = { "~demo::salesdata" };
+    //private static final int[]    expectedCounts = { 3730};
     // private static final String[] datasets = {"~benchmark::integer::20kb"};
     // private static final int[]    expectedCounts = {1250};
 

--- a/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
+++ b/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
@@ -17,6 +17,9 @@ package org.hpccsystems.dfs.client;
 
 import java.util.List;
 import java.util.ArrayList;
+
+import static org.junit.Assert.fail;
+
 import java.security.SecureRandom;
 
 import org.hpccsystems.dfs.client.HPCCFile;
@@ -28,7 +31,7 @@ import org.hpccsystems.dfs.client.ReflectionRecordBuilder;
 import org.hpccsystems.dfs.client.DataPartition;
 
 import org.hpccsystems.dfs.cluster.*;
-
+import org.apache.commons.lang3.StringUtils;
 import org.hpccsystems.commons.ecl.FieldDef;
 import org.hpccsystems.commons.ecl.FieldType;
 import org.hpccsystems.commons.ecl.HpccSrcType;
@@ -45,9 +48,9 @@ import org.junit.Test;
 public class DFSReadWriteTest
 {
 
-    private static final String   clusterIP      = "192.168.56.101";
-    private static final String[] datasets       = { "~benchmark::integer::20kb", "~demo::example_dataset" };
-    private static final int[]    expectedCounts = { 1250, 6 };
+    private static final String   clusterIP      = "10.173.147.1";
+    private static final String[] datasets       = { "~demo::salesdata" };
+    private static final int[]    expectedCounts = { 3730};
     // private static final String[] datasets = {"~benchmark::integer::20kb"};
     // private static final int[]    expectedCounts = {1250};
 
@@ -86,8 +89,24 @@ public class DFSReadWriteTest
             {
                 Assert.fail("Written dataset does not match original dataset: " + copyFileName);
             }
+            
+            //read out a projected layout, confirm that this works
+            
+            List<String> projectedfields=new ArrayList<String>();
+            for (int j=0; j < file.getRecordDefinition().getNumDefs()-1;j++) 
+            {
+                projectedfields.add(file.getRecordDefinition().getDef(j).getFieldName());
+            }            
+            
+            file=new HPCCFile(copyFileName,espConn);
+            FieldDef recdef=file.getRecordDefinition();
+            file.setProjectList(StringUtils.join(projectedfields, ","));
+            List<HPCCRecord> recs=readFile(file);
+            if (recs.get(0).getNumFields() != file.getRecordDefinition().getNumDefs()-1) 
+            {
+                fail("recs did not project correctly");
+            }
         }
-
     }
 
     private static final String       ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_";


### PR DESCRIPTION

Fixes JAPI 184.

Also, I discovered when loading up the latest master that HPCC-commons had a missing/incorrect dependency for log4j preventing the maven compile from working. Updated that pom as part of this PR.

I also updated the cluster info for DFUReadWriteTest to point to a cluster that is currently up and running.

<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [X] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [X] The change has been fully tested:
  - [X] I have performed unit tests to cover my changes.
  - [X] I have performed system test and covered possible regressions and side effects.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->
* Updated the DFUReadWriteTest to test reading out projected recordlayouts.
* Ran mvn install and tested the SALT/hpcc code that had previously been failing against the installed dfuclient jar; the SALT/hpcc code worked. All other SALT/hpcc code referencing dfuclient also still worked.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
