### PR TITLE
JAPI-208 set default dfufiletype to avoid platform error

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsDFUClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsDFUClient.java
@@ -1261,7 +1261,7 @@ public class HPCCWsDFUClient extends DataSingleton
         }
         else if (targetVersion.major > 7 || targetVersion.major == 7 && targetVersion.minor > 0)
         {
-            return createFileAndAcquireAccess(fileName, cluster, eclRecordDefinition, expirySeconds, null, null, null);
+            return createFileAndAcquireAccess(fileName, cluster, eclRecordDefinition, expirySeconds, null, DFUFileTypeWrapper.Flat, null);
         }
         else
             throw new Exception("WSDFU File Create not available on HPCC v" + targetVersion.major + "." + targetVersion.minor);
@@ -1280,7 +1280,7 @@ public class HPCCWsDFUClient extends DataSingleton
      */
     public DFUCreateFileWrapper createFile(String fileName, String cluster, String eclRecordDefinition, int expirySeconds) throws Exception
     {
-        return createFileAndAcquireAccess(fileName, cluster, eclRecordDefinition, expirySeconds, false, null, null);
+        return createFileAndAcquireAccess(fileName, cluster, eclRecordDefinition, expirySeconds, false, DFUFileTypeWrapper.Flat, null);
     }
 
     /**
@@ -1296,7 +1296,7 @@ public class HPCCWsDFUClient extends DataSingleton
      */
     public DFUCreateFileWrapper createFile(String fileName, String cluster, String eclRecordDefinition, int expirySeconds, Boolean compressed) throws Exception
     {
-        return createFileAndAcquireAccess(fileName, cluster, eclRecordDefinition, expirySeconds, compressed, null, null);
+        return createFileAndAcquireAccess(fileName, cluster, eclRecordDefinition, expirySeconds, compressed, DFUFileTypeWrapper.Flat, null);
     }
 
     /**
@@ -1339,6 +1339,7 @@ public class HPCCWsDFUClient extends DataSingleton
         {
             WsDfuServiceSoapProxy proxy = getSoapProxy();
             DFUFileCreateV2Request filecreatereq = new DFUFileCreateV2Request();
+            filecreatereq.setType(DFUFileTypeWrapper.Flat);
             filecreatereq.setECLRecordDefinition(eclRecordDefinition);
             filecreatereq.setCluster(cluster);
             filecreatereq.setExpirySeconds(expirySeconds);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [x] I have created a corresponding JIRA ticket for this submission
- [x] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [x] The change has been fully tested:
  - [ ] I have performed unit tests to cover my changes.
  - [ ] I have performed system test and covered possible regressions and side effects.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
Tested unit tests, and also tested the compiled jar with the hpcc tardis module.