### PR TITLE
JAPI-251 Fix wstopology getvalidtargetclusters

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsTopologyClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsTopologyClient.java
@@ -343,8 +343,9 @@ public class HPCCWsTopologyClient extends BaseHPCCWsClient
                             {
                                 if (clusterGroupType == null || clusterGroupType.isEmpty() || tpClusters[k].getType().equalsIgnoreCase(clusterGroupType+"cluster" ))
                                 {
-                                    if (!tpTargetClusterNames.contains(tpClusters[k].getName()))
-                                        tpTargetClusterNames.add(tpClusters[k].getName());
+                                    //We're looking for the name of the tptargetcluster, not the the child cluster name
+                                    if (!tpTargetClusterNames.contains(tpTargetClusters[i].getName()))
+                                        tpTargetClusterNames.add(tpTargetClusters[i].getName());
                                 }
                             }
                         }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WSTopologyClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WSTopologyClientTest.java
@@ -21,10 +21,6 @@ import java.io.PrintStream;
 import java.util.List;
 
 import org.apache.axis2.AxisFault;
-import org.hpccsystems.ws.client.gen.axis2.wstopology.v1_28.TpClusterInfoResponse;
-import org.hpccsystems.ws.client.gen.axis2.wstopology.v1_28.TpDropZone;
-import org.hpccsystems.ws.client.gen.axis2.wstopology.v1_28.TpLogicalCluster;
-import org.hpccsystems.ws.client.gen.axis2.wstopology.v1_28.TpMachine;
 import org.hpccsystems.ws.client.platform.test.BaseRemoteTest;
 import org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper;
 import org.hpccsystems.ws.client.wrappers.gen.wstopology.TpClusterInfoResponseWrapper;
@@ -143,7 +139,40 @@ public class WSTopologyClientTest extends BaseRemoteTest
         {
             TpClusterInfoResponseWrapper clusterInfo = client.getClusterInfo(validTargetClusterNames[i]);
             System.out.println(clusterInfo.toString());
-          }
+        }
+    }
+
+    @Test
+    public void getInvalidClusterInfoTest()
+    {
+        System.out.println("----------------------get invalid cluster info Test ------------------");
+        String invalid = "invalidclustername";
+        try
+        {
+            client.getClusterInfo(invalid);
+            Assert.fail("Invalid target cluster test should result in exception");
+        }
+        catch (Exception e)
+        {
+            System.out.println("Invalid target cluster test resulted in exception as expected");
+            //  EspException: Audience: user Source: CSoapResponseBinding Message: 2019-11-01 15:19:42 GMT: Invalid Target Cluster name provided: 'mythor'
+        }
+    }
+
+    @Test
+    public void getBlankClusterInfoTest()
+    {
+        System.out.println("----------------------get invalid blank target cluster name Test ------------------");
+        try
+        {
+            client.getClusterInfo("");
+            Assert.fail("Blank target cluster test should result in exception");
+        }
+        catch (Exception e)
+        {
+            System.out.println("Blank target cluster test resulted in exception as expected");
+            //  EspException: Audience: user Source: CSoapResponseBinding Message: 2019-11-01 15:19:42 GMT: Invalid Target Cluster name provided: 'mythor'
+        }
     }
 
     @Test


### PR DESCRIPTION
- Uses correct target cluster names

Signed-off-by: Pastrana, Rodrigo <rodrigo.pastrana@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [x] I have created a corresponding JIRA ticket for this submission
- [x] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [x] The change has been fully tested:
  - [ ] I have performed unit tests to cover my changes.
  - [ ] I have performed system test and covered possible regressions and side effects.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->
Created new junit test cases and ran successfully 
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
