### PR TITLE
JAPI-255 Clarify getavailabletargetclusters vs getavailablecluster

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsClient.java
@@ -484,7 +484,7 @@ public class HPCCWsClient extends DataSingleton
     /**
      * Returns all the available target cluster names (mythor, myroxie, etc) given a cluster group type/name (thor, roxie, etc.)
      * @param clusterGroupType         - The cluster group type/name
-     * @return                         - Names of all availabe target cluster in the given cluster group
+     * @return                         - Names of all available target cluster in the given cluster group
      * @throws Exception
      * @throws org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper 
      */
@@ -493,7 +493,7 @@ public class HPCCWsClient extends DataSingleton
         HPCCWsTopologyClient wsTopologyClient = HPCCWsTopologyClient.get(connection);
 
         if (wsTopologyClient != null)
-            return wsTopologyClient.getValidTargetClusterNames(clusterGroupType);
+            return wsTopologyClient.getValidClusterNames(clusterGroupType);
         else
             throw new Exception("Could not initialize HPCC WsTopology Client");
     }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WsClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WsClientTest.java
@@ -1,0 +1,145 @@
+package org.hpccsystems.ws.client;
+
+import org.hpccsystems.ws.client.platform.test.BaseRemoteTest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WsClientTest extends BaseRemoteTest
+{
+    String thortargetclustername = System.getProperty("thorgroupname");
+    String thorclustername = System.getProperty("thorclustername");
+    String roxietargetclustername = System.getProperty("roxiegroupname");
+    String roxieclustername = System.getProperty("roxieclustername");
+
+    static
+    {
+        if (System.getProperty("thortargetclustername") == null)
+            System.out.println("thortargetclustername not provided - defaulting to 'thor'");
+
+        if (System.getProperty("thorclustername") == null)
+            System.out.println("thorclustername not provided - defaulting to 'mythor'");
+
+        if (System.getProperty("roxietargetclustername") == null)
+            System.out.println("roxietargetclustername not provided - defaulting to 'roxie'");
+
+        if (System.getProperty("roxieclustername") == null)
+            System.out.println("roxieclustername not provided - defaulting to 'myroxie'");
+    }
+
+    @Before
+    public void setup() throws Exception
+    {
+        super.setup();
+
+        if (thortargetclustername == null)
+            thortargetclustername = "thor";
+        if (thorclustername == null)
+            thorclustername = "mythor";
+        if (roxietargetclustername == null)
+            roxietargetclustername = "roxie";
+        if (roxieclustername == null)
+            roxieclustername = "myroxie";
+    }
+
+    @Test
+    public void testAvailableClusterGroups()
+    {
+        try
+        {
+            String[] availableClusterGroups = wsclient.getAvailableClusterGroups();
+            System.out.println("Available (Target) Cluster groups");
+            for (int i = 0; i < availableClusterGroups.length; i++)
+            {
+                System.out.println("\t" + availableClusterGroups[i]);
+            }
+        }
+        catch (Exception e)
+        {
+            Assert.fail("Could not fetch available cluster groups: " + e.getLocalizedMessage());
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testGetAvailableClusterNames()
+    {
+        try
+        {
+            String[] availableClusterGroups = wsclient.getAvailableClusterNames("");
+            System.out.println("Available clusters");
+            for (int i = 0; i < availableClusterGroups.length; i++)
+            {
+                System.out.println("\t" + availableClusterGroups[i]);
+            }
+        }
+        catch (Exception e)
+        {
+            Assert.fail("Could not fetch available cluster names: " + e.getLocalizedMessage());
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testGetAvailableRoxieClusterNames()
+    {
+        try
+        {
+            String[] availableClusterGroups = wsclient.getAvailableClusterNames("roxie");
+            System.out.println("Available roxie clusters");
+            boolean found = false;
+            for (int i = 0; i < availableClusterGroups.length; i++)
+            {
+                if (availableClusterGroups[i].equalsIgnoreCase(roxieclustername))
+                    found = true;
+            }
+            if (!found)
+                Assert.fail("Did not find roxie cluster named: '" + roxieclustername +"'");
+        }
+        catch (Exception e)
+        {
+            Assert.fail("Could not fetch available roxie cluster names: " + e.getLocalizedMessage());
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testGetAvailableThorClusterNames()
+    {
+        try
+        {
+            String[] availableClusterGroups = wsclient.getAvailableClusterNames("thor");
+            System.out.println("Available thor clusters");
+            boolean found = false;
+            for (int i = 0; i < availableClusterGroups.length; i++)
+            {
+                if (availableClusterGroups[i].equalsIgnoreCase(thorclustername))
+                    found = true;
+            }
+            if (!found)
+                Assert.fail("Did not find thor cluster named: '" + thorclustername +"'");
+        }
+        catch (Exception e)
+        {
+            Assert.fail("Could not fetch available thor cluster names: " + e.getLocalizedMessage());
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testPingServer()
+    {
+        try
+        {
+            System.out.println("Pinging server via wsclient");
+            boolean pinged = wsclient.pingServer();
+            if (!pinged)
+                Assert.fail("Could not ping server via wsclient");
+        }
+        catch (Exception e)
+        {
+            Assert.fail("Could not ping server");
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
- Add new method to return available cluster names
- Add test cases for get target clusters, and cluster

Signed-off-by: Pastrana, Rodrigo <rodrigo.pastrana@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [x] I have created a corresponding JIRA ticket for this submission
- [x] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [x] The change has been fully tested:
  - [x] I have performed unit tests to cover my changes.
  - [ ] I have performed system test and covered possible regressions and side effects.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
