### PR TITLE
Japi-277 binaryrecordwriter npes

### DIFF
--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/BinaryRecordWriter.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/BinaryRecordWriter.java
@@ -250,7 +250,7 @@ public class BinaryRecordWriter implements IRecordWriter
         {
             case BINARY:
             {
-                byte[] data = (byte[]) fieldValue;
+                byte[] data = fieldValue==null?new byte[0]:(byte[]) fieldValue;
                 long dataSize = data.length;
                 writeUnsigned(dataSize);
                 writeByteArray(data);

--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/BinaryRecordWriter.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/BinaryRecordWriter.java
@@ -270,7 +270,8 @@ public class BinaryRecordWriter implements IRecordWriter
             case INTEGER:
             {
                 Long value = null;
-                if (fieldValue==null) {
+                if (fieldValue==null) 
+                {
                     value=new Long(0);
                 }
                 else if (fieldValue instanceof Long)

--- a/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
+++ b/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
@@ -40,18 +40,20 @@ import org.hpccsystems.commons.ecl.RecordDefinitionTranslator;
 import org.hpccsystems.commons.errors.HpccFileException;
 import org.hpccsystems.ws.client.HPCCWsDFUClient;
 import org.hpccsystems.ws.client.platform.test.BaseRemoteTest;
-import org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper;
 import org.hpccsystems.ws.client.wrappers.wsdfu.DFUCreateFileWrapper;
 import org.hpccsystems.ws.client.wrappers.wsdfu.DFUFilePartWrapper;
 import org.hpccsystems.ws.client.wrappers.wsdfu.DFUFileTypeWrapper;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runners.MethodSorters;
 
 
 @Category(RemoteTests.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class DFSReadWriteTest extends BaseRemoteTest
 {
     private static final String[] datasets       = { "~benchmark::integer::20kb"};
@@ -113,7 +115,7 @@ public class DFSReadWriteTest extends BaseRemoteTest
     @Test
     public void nullWriteTest() throws Exception
     {
-        String fname="~test::mostdatatypes";
+        String fname="~test::alldatatypes";
         HPCCFile file = new HPCCFile(fname, connString, hpccUser, hpccPass);
         file.setProjectList("");
         List<HPCCRecord> records = readFile(file);
@@ -331,6 +333,7 @@ public class DFSReadWriteTest extends BaseRemoteTest
                 }
                 catch (Exception e)
                 {
+                    e.printStackTrace();
                     Assert.fail(e.getMessage());
                 }
             }

--- a/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
+++ b/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
@@ -18,8 +18,10 @@ package org.hpccsystems.dfs.client;
 import java.util.List;
 import java.util.ArrayList;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.math.BigDecimal;
 import java.security.SecureRandom;
 
 import org.hpccsystems.dfs.client.HPCCFile;
@@ -52,7 +54,7 @@ import org.junit.experimental.categories.Category;
 @Category(RemoteTests.class)
 public class DFSReadWriteTest extends BaseRemoteTest
 {
-    private static final String[] datasets       = { "~benchmark::integer::20kb", "~demo::example_dataset"};
+    private static final String[] datasets       = { "~benchmark::integer::20kb"};
     private static final int[]    expectedCounts = { 1250, 6 };
 
     @Before
@@ -106,6 +108,42 @@ public class DFSReadWriteTest extends BaseRemoteTest
             }
         }
     }
+
+
+    @Test
+    public void nullWriteTest() throws Exception
+    {
+        String fname="~test::mostdatatypes";
+        HPCCFile file = new HPCCFile(fname, connString, hpccUser, hpccPass);
+        file.setProjectList("");
+        List<HPCCRecord> records = readFile(file);
+        assertEquals( "Record count mismatch for dataset:" + fname + ". got: " + records.size() + " expected:" + 5600,5600,records.size());
+
+        HPCCRecord first = records.get(0);
+        for (int f = 0; f < first.getNumFields(); f++)
+        {
+            first.setField(f, null);
+        }
+
+        // Write the dataset back
+        String copyFileName = fname + "_copy";
+        writeFile(records, copyFileName, file.getProjectedRecordDefinition());
+
+        file = new HPCCFile(copyFileName, connString, hpccUser, hpccPass);
+        records = readFile(file);
+        assertEquals( "Record count mismatch for dataset:" + copyFileName + ". got: " + records.size() + " expected:" + 5600,5600,records.size());
+
+        HPCCRecord rec0 = records.get(0);
+        assertEquals((String) rec0.getField(0), "");
+        assertEquals((Boolean) rec0.getField(1), false);
+        assertEquals((Long) rec0.getField(2), new Long(0));
+        assertEquals((Long) rec0.getField(3), new Long(0));
+        assertEquals((Long) rec0.getField(4), new Long(0));
+        assertEquals((Double) rec0.getField(5), new Double(0.0));
+        assertEquals(((BigDecimal) rec0.getField(6)).intValue(),0);
+
+    }
+    
 
     private static final String       ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_";
     private static final SecureRandom RANDOM   = new SecureRandom();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [x] I have created a corresponding JIRA ticket for this submission
- [x] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [x] The change has been fully tested:
  - [ ] I have performed unit tests to cover my changes.
  - [ ] I have performed system test and covered possible regressions and side effects.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->
Created a unit test that tested writing null values for ecl types STRING, BOOLEAN, INTEGER2, INTEGER8,UNSIGNED8, REAL8, DECIMAL5_2, DATA, UTF8, UNICODE and ENUM. Default values ("" for string, false for boolean, 0 for null numerics and enum) were correctly written.

Also reran all other ReadWriteDFUTest use cases.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
