### PR TITLE
JAPI-285 DFSClient: HPCCFile setFilter does not work if partitions ha…

### DIFF
--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/DataPartition.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/DataPartition.java
@@ -300,6 +300,17 @@ public class DataPartition implements Serializable
     {
         return this.fileFilter;
     }
+    
+    /**
+     * Set the filter object to select specific rows.
+     * 
+     * @return the partition
+     */
+    public DataPartition setFilter(FileFilter filter)
+    {
+        this.fileFilter = filter;
+        return this;
+    }
 
     /*
      * (non-Javadoc)


### PR DESCRIPTION
…ve already been created

- Corrected setFilter to modify exisiting dataparts
- Added setFilter method to DataPartition

Signed-off-by: James McMullan <James.McMullan@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
  - [X] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [X] The change has been fully tested:
  - [ ] I have performed unit tests to cover my changes.
  - [ ] I have performed system test and covered possible regressions and side effects.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
