### PR TITLE
JAPI-286 Improve RemoteUnitTest performance

### DIFF
--- a/commons-hpcc/src/main/java/org/hpccsystems/commons/ecl/FileFilter.java
+++ b/commons-hpcc/src/main/java/org/hpccsystems/commons/ecl/FileFilter.java
@@ -327,7 +327,8 @@ public class FileFilter implements Serializable
      */
     private void ConvertToHPCCFileFilter(String sqlfilterstr) throws Exception
     {
-        if (sqlfilterstr == null || sqlfilterstr.isEmpty()) throw new Exception("Cannot convert empty SQL Filter");
+        if (sqlfilterstr == null || sqlfilterstr.isEmpty())
+            throw new Exception("Cannot convert empty SQL Filter");
 
         try
         {
@@ -338,7 +339,8 @@ public class FileFilter implements Serializable
         }
         catch (SQLException e)
         {
-            e.printStackTrace();
+            log.error(e.getMessage());
+            throw e;
         }
     }
 

--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/HPCCFile.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/HPCCFile.java
@@ -1,13 +1,13 @@
 /*
  * ##############################################################################
- * 
+ *
  * HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems®.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -133,7 +133,8 @@ public class HPCCFile implements Serializable
         this.espConnInfo = espconninfo;
         try
         {
-            if (filter != null && !filter.isEmpty()) this.filter = new FileFilter(filter);
+            if (filter != null && !filter.isEmpty())
+                this.filter = new FileFilter(filter);
         }
         catch (Exception e)
         {
@@ -141,6 +142,7 @@ public class HPCCFile implements Serializable
         }
 
         clusterRemapInfo = remap_info;
+        this.targetfilecluster = targetfilecluster;
     }
 
     /**
@@ -309,14 +311,12 @@ public class HPCCFile implements Serializable
         long fileAccessExpiryMS = fileAccessExpirySecs * 1000;
         long dataPartsAgeMS = System.currentTimeMillis() - dataPartsCreationTimeMS;
         boolean accessTokenExpired = dataPartsAgeMS >= fileAccessExpiryMS;
-        if (dataParts != null && !accessTokenExpired)
+        if (dataParts != null)
         {
-            return;
-        }
-
-        if (accessTokenExpired)
-        {
-            log.info("Refreshing data parts due to access token expiration.");
+            if (accessTokenExpired)
+                log.info("Refreshing data parts due to access token expiration.");
+            else
+                return;
         }
 
         dataPartsCreationTimeMS = System.currentTimeMillis();

--- a/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSBenchmarkTest.java
+++ b/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSBenchmarkTest.java
@@ -15,10 +15,7 @@
  *******************************************************************************/
 package org.hpccsystems.dfs.client;
 
-import java.util.List;
 import java.util.ArrayList;
-
-import static org.junit.Assert.fail;
 
 import org.hpccsystems.dfs.client.HPCCFile;
 import org.hpccsystems.dfs.client.HPCCRecord;
@@ -26,13 +23,11 @@ import org.hpccsystems.dfs.client.HPCCRecordBuilder;
 import org.hpccsystems.dfs.client.HpccRemoteFileReader;
 import org.hpccsystems.dfs.client.DataPartition;
 
-import org.hpccsystems.dfs.cluster.*;
 import org.hpccsystems.commons.ecl.FieldDef;
 import org.hpccsystems.commons.errors.HpccFileException;
 import org.hpccsystems.ws.client.platform.test.BaseRemoteTest;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -42,12 +37,6 @@ public class DFSBenchmarkTest extends BaseRemoteTest
     private static final String[] datasets = {"benchmark::integer::100mb","benchmark::string::100mb","benchmark::varstring::100mb","benchmark::utf8::100mb",
                                             "benchmark::unicode::100mb","benchmark::real::100mb","benchmark::decimal::100mb"};
     private static final float[] minDatasetConstructionEfficiency = {0.90f,0.90f,0.90f,0.90f,0.90f,0.90f,0.90f};
-
-    @Before
-    public void setup() throws Exception
-    {
-        super.setup();
-    }
 
     @Test
     public void integrationReadBenchmark() throws Exception

--- a/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSHPCCFile.java
+++ b/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSHPCCFile.java
@@ -1,0 +1,188 @@
+package org.hpccsystems.dfs.client;
+
+import static org.junit.Assert.*;
+
+import java.net.MalformedURLException;
+import org.hpccsystems.commons.ecl.FieldDef;
+import org.hpccsystems.commons.ecl.FileFilter;
+import org.hpccsystems.commons.errors.HpccFileException;
+import org.hpccsystems.dfs.cluster.RemapInfo;
+import org.hpccsystems.ws.client.platform.test.BaseRemoteTest;
+import org.hpccsystems.ws.client.utils.Connection;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(RemoteTests.class)
+public class DFSHPCCFile extends BaseRemoteTest
+{
+    private static HPCCFile mockHPCCFile = null;
+
+    private static final String mockValidFileName = "some::file::name";
+    private static final String mockValidURL = "http://someesp:8010/somepath";
+    private static final String mockProjectList = "uint8,r8,varStr,";
+    private static final String mockFilter = "uint8 > 2";
+    private static final String mockIP = "10.1.1.1";
+    private static Connection mockConnectionObj = null;
+    private static final String mockTargetFileCluster = "thor";
+    private static RemapInfo mockRemapInfo = new RemapInfo(100, mockIP);
+    private static final int mockFilePartsMax = 2;
+
+    @Before
+    public void setup() throws HpccFileException
+    {
+        mockHPCCFile = new HPCCFile(DEFAULTHPCCFILENAME, connection, mockProjectList, mockFilter, mockRemapInfo, mockFilePartsMax, thorcluster);
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Test
+    public final void testHPCCFileStringConnection()
+    {
+        HPCCFile testfile = null;
+        try
+        {
+            testfile = new HPCCFile(mockValidFileName, mockConnectionObj);
+            Assert.assertNotNull(testfile);
+        }
+        catch (HpccFileException e)
+        {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public final void testHPCCFileStringStringStringString() throws MalformedURLException, HpccFileException
+    {
+        HPCCFile testfile = new HPCCFile(mockValidFileName, mockValidURL, "user", "pass");
+        Assert.assertNotNull(testfile);
+    }
+
+    @Test
+    public final void testHPCCFileStringConnectionStringStringRemapInfoIntString() throws HpccFileException
+    {
+        HPCCFile testfile = new HPCCFile(mockValidFileName, mockConnectionObj, mockProjectList, mockFilter, mockRemapInfo, 400, mockTargetFileCluster);
+        Assert.assertNotNull(testfile);
+    }
+
+    @Test(expected = org.hpccsystems.commons.errors.HpccFileException.class)
+    public final void testHPCCFileStringConnectionStringStringRemapInfoIntStringBadFilter() throws HpccFileException
+    {
+        new HPCCFile(mockValidFileName, mockConnectionObj, mockProjectList, "invalidFilter", mockRemapInfo, 400, mockTargetFileCluster);
+    }
+
+    @Test
+    public final void testHPCCFileStringConnectionStringStringRemapInfoIntStringEmptyFilter() throws HpccFileException
+    {
+        new HPCCFile(mockValidFileName, mockConnectionObj, mockProjectList, "", mockRemapInfo, 400, mockTargetFileCluster);
+    }
+
+    @Test
+    public final void testGetProjectList()
+    {
+        String projectList = mockHPCCFile.getProjectList();
+        Assert.assertEquals(mockProjectList, projectList);
+    }
+
+    @Test(expected = Exception.class)
+    public final void testSetProjectListInvalidColumns() throws Exception
+    {
+        mockHPCCFile.setProjectList("colX, colY, colZ");
+        mockHPCCFile.getRecordDefinition();
+    }
+
+    @Test
+    public final void testGetTargetfilecluster()
+    {
+        Assert.assertEquals(thorcluster, mockHPCCFile.getTargetfilecluster());
+    }
+
+    @Test(expected = HpccFileException.class)
+    public final void testSetTargetfilecluster() throws HpccFileException
+    {
+        mockHPCCFile.getRecordDefinition();//ensures fileparts created
+        mockHPCCFile.setTargetfilecluster("randomname");
+        mockHPCCFile.getRecordDefinition(); //makes sure the new cluster took affect
+    }
+
+    @Test
+    public final void testGetClusterRemapInfo()
+    {
+        Assert.assertEquals(mockRemapInfo, mockHPCCFile.getClusterRemapInfo());
+    }
+
+    @Test
+    public final void testSetClusterRemapInfo() throws HpccFileException
+    {
+        mockHPCCFile.getRecordDefinition(); //force filepart creation
+
+        RemapInfo newremapInfo = new RemapInfo(100, "1"+mockIP);
+        mockHPCCFile.setClusterRemapInfo(newremapInfo);
+        DataPartition[] fileParts = mockHPCCFile.getFileParts();
+        Assert.assertNotNull(fileParts);
+        Assert.assertTrue(fileParts.length > 0);
+        String[] copyLocations = fileParts[0].getCopyLocations();
+        Assert.assertNotNull(copyLocations);
+        Assert.assertTrue(copyLocations.length > 0);
+        Assert.assertEquals("1"+mockIP, copyLocations[0]);
+    }
+
+    @Test
+    public final void testGetFilter() throws Exception
+    {
+        mockHPCCFile.setFilter(mockFilter);
+        FileFilter firstfilter = mockHPCCFile.getFilter();
+        Assert.assertNotNull(firstfilter);
+        mockHPCCFile.setFilter(mockFilter+" OR uint8 > 2");
+        FileFilter secondfilter = mockHPCCFile.getFilter();
+        Assert.assertNotNull(secondfilter);
+        Assert.assertFalse(firstfilter.toString().equals(secondfilter.toString()));
+    }
+
+    @Test(expected = Exception.class)
+    public final void testSetFilterInvalid() throws Exception
+    {
+        mockHPCCFile.setFilter("Invalidfilter=*1");
+    }
+
+    @Test
+    public final void testGetFileName()
+    {
+        Assert.assertEquals(DEFAULTHPCCFILENAME, mockHPCCFile.getFileName());
+    }
+
+    @Test
+    public final void testGetFileParts() throws HpccFileException
+    {
+        DataPartition[] fileParts = mockHPCCFile.getFileParts();
+        Assert.assertNotNull(fileParts);
+        Assert.assertTrue(fileParts.length > 0);
+    }
+
+    @Test
+    public final void testGetRecordDefinition() throws HpccFileException
+    {
+        FieldDef recordDefinition = mockHPCCFile.getRecordDefinition();
+        Assert.assertNotNull(recordDefinition);
+        Assert.assertEquals(21, recordDefinition.getNumDefs());
+    }
+
+    @Test
+    public final void testGetProjectedRecordDefinition() throws HpccFileException
+    {
+        FieldDef projectedRecordDefinition = mockHPCCFile.getProjectedRecordDefinition();
+        Assert.assertNotNull(projectedRecordDefinition);
+        Assert.assertEquals(3, projectedRecordDefinition.getNumDefs());
+    }
+
+    @Test
+    public final void testIsIndex()
+    {
+        Assert.assertFalse(mockHPCCFile.isIndex());
+    }
+
+}

--- a/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
+++ b/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
@@ -45,7 +45,6 @@ import org.hpccsystems.ws.client.wrappers.wsdfu.DFUFilePartWrapper;
 import org.hpccsystems.ws.client.wrappers.wsdfu.DFUFileTypeWrapper;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -58,13 +57,6 @@ public class DFSReadWriteTest extends BaseRemoteTest
 {
     private static final String[] datasets       = { "~benchmark::integer::20kb"};
     private static final int[]    expectedCounts = { 1250, 6 };
-
-    @Before
-    public void setup() throws Exception
-    {
-        super.setup();
-    }
-
     
     @Test
     public void readBadlyDistributedFileTest() throws Exception

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/test/BaseRemoteTest.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/test/BaseRemoteTest.java
@@ -17,75 +17,76 @@
 
 package org.hpccsystems.ws.client.platform.test;
 
+import static org.junit.Assert.fail;
+
 import java.net.InetAddress;
+import java.net.MalformedURLException;
 import java.net.UnknownHostException;
 
 import org.hpccsystems.ws.client.HPCCWsClient;
 import org.hpccsystems.ws.client.platform.Platform;
 import org.hpccsystems.ws.client.utils.Connection;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.experimental.categories.Category;
 
 @Category(RemoteTest.class)
 public abstract class BaseRemoteTest
 {
-    protected Platform platform;
-    protected HPCCWsClient wsclient;
+    protected static Platform platform;
+    protected static HPCCWsClient wsclient;
 
-    protected String connString = System.getProperty("hpccconn");
-    protected String thorcluster = System.getProperty("thorcluster");
-    protected Connection connection = null;
+    protected final static String connString = System.getProperty("hpccconn", "http://localhost:8010");
+    protected final static String thorcluster = System.getProperty("thorcluster", "mythor");
+    protected static Connection connection = null;
 
-    protected String hpccUser = System.getProperty("hpccuser");
-    protected String hpccPass = System.getProperty("hpccpass");
-    protected String connTO = System.getProperty("connecttimeoutmillis");
-    protected String sockTO = System.getProperty("sockettimeoutmillis");
+    protected final static String hpccUser = System.getProperty("hpccuser", "");
+    protected final static String hpccPass = System.getProperty("hpccpass", "");
+    protected final static String connTO = System.getProperty("connecttimeoutmillis");
+    protected final static String sockTO = System.getProperty("sockettimeoutmillis");
 
     /*
-     * Code used to generate HPCC file
-     * unique_keys :=  100000;  // Should be less than number of records
-     * unique_values := 10212; // Should be less than number of records
-     * dataset_name := '~benchmark::all_types::200KB';
-     * totalrecs := 779449/500;
-     *
-     * childRec := {STRING8 childField1, INTEGER8 childField2, REAL8 childField3};
-     *
-     * rec := { INTEGER8 int8, UNSIGNED8 uint8, INTEGER4 int4, UNSIGNED4 uint4,
-     *          INTEGER2 int2, UNSIGNED2 uint2, REAL8 r8, REAL4 r4,
-     *          DECIMAL16_8 dec16, UDECIMAL16_8 udec16, QSTRING qStr,
-     *          STRING8 fixStr8, STRING str, VARSTRING varStr, VARSTRING varStr8,
-     *          UTF8 utfStr, UNICODE8 uni8, UNICODE uni, VARUNICODE varUni,
-     *          DATASET(childRec) childDataset,  SET OF INTEGER1 int1Set
-     *        };
-     *
-     *        ds := DATASET(totalrecs, transform(rec,
-     *                             self.int8 := (INTEGER)(random() % unique_keys);
-     *                             self.uint8 := (INTEGER)(random() % unique_values);
-     *                             self.int4 := (INTEGER)(random() % unique_values);
-     *                             self.uint4 := (INTEGER)(random() % unique_values);
-     *                             self.int2 := (INTEGER)(random() % unique_values);
-     *                             self.uint2 := (INTEGER)(random() % unique_values);
-     *                             self.r8 := (REAL)(random() % unique_values);
-     *                             self.r4 := (REAL)(random() % unique_values);
-     *                             self.dec16 := (REAL)(random() % unique_values);
-     *                             self.udec16 := (REAL)(random() % unique_values);
-     *                             self.qStr := (STRING)(random() % unique_values);
-     *                             self.fixStr8 := (STRING)(random() % unique_values);
-     *                             self.str := (STRING)(random() % unique_values);
-     *                             self.varStr := (STRING)(random() % unique_values);
-     *                             self.varStr8 := (STRING)(random() % unique_values);
-     *                             self.utfStr := (STRING)(random() % unique_values);
-     *                             self.uni8 := (STRING)(random() % unique_values);
-     *                             self.uni := (STRING)(random() % unique_values);
-     *                             self.varUni := (STRING)(random() % unique_values);
-     *                             self.childDataset := DATASET([{'field1',2,3},{'field1',2,3}],childRec);
-     *                             self.int1Set := [1,2,3];
-     *                      ), DISTRIBUTED);
-     *         OUTPUT(ds,,dataset_name,overwrite);
-     *
+      Code used to generate HPCC file
+      unique_keys :=  100000;  // Should be less than number of records
+      unique_values := 10212; // Should be less than number of records
+      dataset_name := '~benchmark::all_types::200KB';
+      totalrecs := 779449/500;
+     
+      childRec := {STRING8 childField1, INTEGER8 childField2, REAL8 childField3};
+     
+      rec := { INTEGER8 int8, UNSIGNED8 uint8, INTEGER4 int4, UNSIGNED4 uint4,
+               INTEGER2 int2, UNSIGNED2 uint2, REAL8 r8, REAL4 r4,
+               DECIMAL16_8 dec16, UDECIMAL16_8 udec16, QSTRING qStr,
+               STRING8 fixStr8, STRING str, VARSTRING varStr, VARSTRING varStr8,
+               UTF8 utfStr, UNICODE8 uni8, UNICODE uni, VARUNICODE varUni,
+               DATASET(childRec) childDataset,  SET OF INTEGER1 int1Set
+             };
+     
+             ds := DATASET(totalrecs, transform(rec,
+                                  self.int8 := (INTEGER)(random() % unique_keys);
+                                  self.uint8 := (INTEGER)(random() % unique_values);
+                                  self.int4 := (INTEGER)(random() % unique_values);
+                                  self.uint4 := (INTEGER)(random() % unique_values);
+                                  self.int2 := (INTEGER)(random() % unique_values);
+                                  self.uint2 := (INTEGER)(random() % unique_values);
+                                  self.r8 := (REAL)(random() % unique_values);
+                                  self.r4 := (REAL)(random() % unique_values);
+                                  self.dec16 := (REAL)(random() % unique_values);
+                                  self.udec16 := (REAL)(random() % unique_values);
+                                  self.qStr := (STRING)(random() % unique_values);
+                                  self.fixStr8 := (STRING)(random() % unique_values);
+                                  self.str := (STRING)(random() % unique_values);
+                                  self.varStr := (STRING)(random() % unique_values);
+                                  self.varStr8 := (STRING)(random() % unique_values);
+                                  self.utfStr := (STRING)(random() % unique_values);
+                                  self.uni8 := (STRING)(random() % unique_values);
+                                  self.uni := (STRING)(random() % unique_values);
+                                  self.varUni := (STRING)(random() % unique_values);
+                                  self.childDataset := DATASET([{'field1',2,3},{'field1',2,3}],childRec);
+                                  self.int1Set := [1,2,3];
+                           ), DISTRIBUTED);
+              OUTPUT(ds,,dataset_name,overwrite);
      */
+     
 
     public static final String DEFAULTHPCCFILENAME      = "benchmark::all_types::200kb";
 
@@ -108,7 +109,7 @@ public abstract class BaseRemoteTest
         {
             ip = InetAddress.getLocalHost();
             hostname = ip.getHostName();
-            System.out.println("Remote test executing on: " + hostname + "(" + ip + ")");
+            System.out.println("RemoteTest executing on: " + hostname + "(" + ip + ")");
         }
         catch (UnknownHostException e)
         {
@@ -116,36 +117,34 @@ public abstract class BaseRemoteTest
         }
 
         if (System.getProperty("hpccconn") == null)
-            System.out.println("RemoteTest: No 'hpccconnnect' provided, defaulting to http://localhost:8010");
+            System.out.println("RemoteTest: No 'hpccconn' provided, defaulting to http://localhost:8010");
+        else
+        	System.out.println("RemoteTest: 'hpccconn' set to: '" + connString + "'");
 
         if (System.getProperty("hpccuser") == null)
             System.out.println("RemoteTest: No 'hpccuser' provided.");
+        else
+        	System.out.println("RemoteTest: 'hpccuser' set to: '" + hpccUser + "'");
 
         if (System.getProperty("hpccpass") == null)
             System.out.println("RemoteTest: No 'hpccpass' provided.");
 
         if (System.getProperty("thorcluster") == null)
             System.out.println("RemoteTest: No 'thorcluster' provided, using 'mythor'");
-    }
-
-    @Before
-    public void setup() throws Exception
-    {
+        else
+        	System.out.println("RemoteTest: 'thorcluster' set to: '" + thorcluster + "'");
+        
         if (platform == null)
         {
-            if (connString == null)
-                connString = "http://localhost:8010";
+            try
+            {
+				connection = new Connection(connString);
+			}
+            catch (MalformedURLException e)
+            {
+				fail("Could not adquire connection object based on: '" + connString + "' - " + e.getLocalizedMessage());
+			}
 
-            if (hpccUser == null)
-                hpccUser = "";
-
-            if (hpccPass == null)
-                hpccPass = "";
-
-            if (thorcluster == null)
-                thorcluster = "mythor";
-
-            connection = new Connection(connString);
             Assert.assertNotNull("Could not adquire connection object", connection);
             connection.setCredentials(hpccUser, hpccPass);
 
@@ -165,25 +164,9 @@ public abstract class BaseRemoteTest
         }
         catch (Exception e)
         {
-            e.printStackTrace();
+        	fail("Could not adquire wsclient object: " + e.getMessage() );
         }
 
         Assert.assertNotNull("Could not adquire wsclient object", wsclient);
-    }
-
-    @After
-    public void shutdown()
-    {
-        if (platform != null && wsclient != null)
-        {
-            try
-            {
-                platform.checkInHPCCWsClient(wsclient);
-            }
-            catch (Exception e)
-            {
-                e.printStackTrace();
-            }
-        }
     }
 }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/BaseWsAttributesClientIntegrationTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/BaseWsAttributesClientIntegrationTest.java
@@ -45,8 +45,6 @@ public abstract class BaseWsAttributesClientIntegrationTest extends BaseRemoteTe
     @Before
     public void setup() throws Exception
     {
-        super.setup(); // fetch hpcc connection info and setup platform and wsclient
-
         if (wsattport == null)
             wsattport = "8145";
 
@@ -57,12 +55,6 @@ public abstract class BaseWsAttributesClientIntegrationTest extends BaseRemoteTe
 
         wsattclient = wsclient.getWsAttributesClient(wsattport);
         wsattclient.setVerbose(true);
-    }
-
-    @After
-    public void shutdown()
-    {
-        super.shutdown();
     }
 
     @Test

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/BaseWsWorkunitsClientIntegrationTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/BaseWsWorkunitsClientIntegrationTest.java
@@ -38,8 +38,6 @@ public abstract class BaseWsWorkunitsClientIntegrationTest extends BaseRemoteTes
     @Before
     public void setup() throws Exception
     {
-        super.setup(); // fetch hpcc connection info and setup platform and wsclient
-
         thorcluster=platform.getCluster(getThorClusterName());
         roxiecluster =platform.getCluster(getRoxieClusterName());
         hthorcluster=platform.getCluster(getHthorClusterName());

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/FileSprayClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/FileSprayClientTest.java
@@ -17,6 +17,7 @@ import org.hpccsystems.ws.client.wrappers.gen.filespray.DropZoneFilesResponseWra
 import org.hpccsystems.ws.client.wrappers.gen.filespray.DropZoneWrapper;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -25,12 +26,12 @@ import static org.junit.Assert.assertTrue;
 
 public class FileSprayClientTest extends BaseRemoteTest
 {
-    private HPCCFileSprayClient filesprayclient = null;
+    private HPCCFileSprayClient filesprayclient = wsclient.getFileSprayClient();;
     private String              dropzoneName    = System.getProperty("dropzoneName");
     private List<String>        fileNames       = new ArrayList<>();
-    private String              testFile1       = System.getProperty("dropzoneTestFile1");
-    private String              path            = System.getProperty("dropzonePath");
-    private String              os              = System.getProperty("dropzoneOs");
+    private final static String              testFile1       = System.getProperty("dropzoneTestFile1", "myfilename.txt");
+    private final static String              path            = System.getProperty("dropzonePath", "/path/to/dropzone");
+    private final static String              os              = System.getProperty("dropzoneOs", "");
 
     public static final String DELETE_ACTION              = "Delete";
     public static final String SUCCESS_RESULT             = "Success";
@@ -51,26 +52,10 @@ public class FileSprayClientTest extends BaseRemoteTest
             System.out.println("dropzoneOs not provided - defaulting to ''");
     }
 
-    @Before
+    @BeforeClass
     public void setUp() throws Exception
     {
-        super.setup();
-
-        filesprayclient = wsclient.getFileSprayClient();
-        Assert.assertNotNull(filesprayclient);
-
-        if (testFile1 == null)
-            testFile1 = "myfilename.txt";
         fileNames.add(testFile1);
-
-        if (dropzoneName == null)
-            dropzoneName = "someDropzone";
-
-        if (path == null)
-            path = "/path/to/dropzone";
-
-        if (os == null)
-            os = "";
     }
 
     @Test

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WSFileIOClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WSFileIOClientTest.java
@@ -37,10 +37,10 @@ import org.junit.runners.MethodSorters;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class WSFileIOClientTest extends BaseRemoteTest
 {
-    HPCCWsFileIOClient client;
+    private final static HPCCWsFileIOClient client = wsclient.getWsFileIOClient();
 
-    String testfilename = System.getProperty("lztestfile");
-    String targetLZ = System.getProperty("lzname");
+    private final static String testfilename = System.getProperty("lztestfile", "myfilename.txt");
+    private final static  String targetLZ = System.getProperty("lzname", "localhost");
 
     static
     {
@@ -49,18 +49,6 @@ public class WSFileIOClientTest extends BaseRemoteTest
 
         if (System.getProperty("lzname") == null)
             System.out.println("lzname not provided - defaulting to localhost");
-    }
-
-    @Before
-    public void setup() throws Exception
-    {
-        super.setup();
-        client = wsclient.getWsFileIOClient();
-        Assert.assertNotNull(client);
-        if (testfilename == null)
-            testfilename = "myfilename.txt";
-        if (targetLZ == null)
-            targetLZ = "localhost";
     }
 
     @Test

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WSPackageProcessTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WSPackageProcessTest.java
@@ -20,7 +20,6 @@ package org.hpccsystems.ws.client;
 import org.apache.axis2.AxisFault;
 import org.hpccsystems.ws.client.platform.test.BaseRemoteTest;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -28,15 +27,7 @@ import org.junit.runners.MethodSorters;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class WSPackageProcessTest extends BaseRemoteTest
 {
-    HPCCWsPackageProcessClient client;
-
-    @Before
-    public void setup() throws Exception
-    {
-        super.setup();
-        client = wsclient.getWsPackageProcessClient();
-        Assert.assertNotNull(client);
-    }
+    HPCCWsPackageProcessClient client = wsclient.getWsPackageProcessClient();
 
     @Test
     public void ping() throws Exception

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WSSQLClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WSSQLClientTest.java
@@ -39,7 +39,6 @@ import org.hpccsystems.ws.client.wrappers.gen.wssql.QuerySetAliases_type0Wrapper
 import org.hpccsystems.ws.client.wrappers.gen.wssql.QuerySetQueries_type0Wrapper;
 import org.hpccsystems.ws.client.wrappers.gen.wssql.QuerySignatureWrapper;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -47,40 +46,27 @@ import org.junit.runners.MethodSorters;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class WSSQLClientTest extends BaseRemoteTest
 {
-    HPCCWsSQLClient client;
-    String testwuid = System.getProperty("targetwuid");
-    String wssqlport = System.getProperty("wssqlport");
+    private final static HPCCWsSQLClient client;
+    private final static String testwuid = System.getProperty("targetwuid");
+    private final static String wssqlport = System.getProperty("wssqlport", "8510");
 
     String randomtablename = null;
     String randomclustername = null;
 
     static
     {
+        Connection wssqlconn = new Connection(connection.getProtocol(), connection.getHost(), wssqlport);
+        Assert.assertNotNull(wssqlconn);
+        wssqlconn.setCredentials(connection.getUserName(), connection.getPassword());
+
+        client = HPCCWsSQLClient.get(wssqlconn);
+        Assert.assertNotNull(client);
+
         if (System.getProperty("targetwuid") == null)
             System.out.println("No targetwuid provided");
 
         if (System.getProperty("wssqlport") == null)
             System.out.println("No wssqlport specified - defaulting to 8510");
-    }
-
-    @Before
-    public void setup() throws Exception
-    {
-        if (platform == null)
-            super.setup();
-
-        if (client == null)
-        {
-            if (wssqlport == null || wssqlport.isEmpty())
-                wssqlport = "8510";
-
-            Connection wssqlconn = new Connection(connection.getProtocol(), connection.getHost(), wssqlport);
-            Assert.assertNotNull(wssqlconn);
-            wssqlconn.setCredentials(connection.getUserName(), connection.getPassword());
-
-            client = HPCCWsSQLClient.get(wssqlconn);
-        }
-        Assert.assertNotNull(client);
     }
 
     @Test

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WSStoreClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WSStoreClientTest.java
@@ -39,10 +39,11 @@ import org.junit.runners.MethodSorters;
 public class WSStoreClientTest extends BaseRemoteTest
 {
     HPCCWsStoreClient client;
-    static protected String storename = System.getProperty("storename");
-    static protected String namespace = System.getProperty("storenamespace");
     public final static String defaultStoreName = "WsClientTestStore";
     public final static String defaultNS = "Junittests";
+
+    private final static String storename = System.getProperty("storename", defaultStoreName);
+    private final static String namespace = System.getProperty("storenamespace");
 
     static
     {
@@ -56,17 +57,8 @@ public class WSStoreClientTest extends BaseRemoteTest
     @Before
     public void setup() throws Exception
     {
-        if (platform == null)
-            super.setup();
-
         if (client == null)
             client = HPCCWsStoreClient.get(connection);
-
-        if (storename == null)
-            storename = defaultStoreName;
-
-        if (namespace == null)
-            namespace = defaultNS;
 
         Assert.assertNotNull(client);
     }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WSTopologyClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WSTopologyClientTest.java
@@ -28,7 +28,6 @@ import org.hpccsystems.ws.client.wrappers.gen.wstopology.TpDropZoneWrapper;
 import org.hpccsystems.ws.client.wrappers.gen.wstopology.TpLogicalClusterWrapper;
 import org.hpccsystems.ws.client.wrappers.gen.wstopology.TpMachineWrapper;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -36,19 +35,7 @@ import org.junit.runners.MethodSorters;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class WSTopologyClientTest extends BaseRemoteTest
 {
-    HPCCWsTopologyClient client;
-
-    @Before
-    public void setup() throws Exception
-    {
-        if (platform == null)
-            super.setup();
-
-        if (client == null)
-            client = wsclient.getWsTopologyClient();
-
-        Assert.assertNotNull(client);
-    }
+    HPCCWsTopologyClient client = wsclient.getWsTopologyClient();
 
     @Test
     public void printValidTargetClustersTest() throws Exception, ArrayOfEspExceptionWrapper

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WSWorkunitsTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WSWorkunitsTest.java
@@ -25,6 +25,7 @@ import org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper;
 import org.hpccsystems.ws.client.wrappers.wsworkunits.WorkunitWrapper;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -32,17 +33,14 @@ import org.junit.runners.MethodSorters;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class WSWorkunitsTest extends BaseRemoteTest
 {
-    HPCCWsWorkUnitsClient client;
-    String                testwuid = System.getProperty("targetwuid");
+    private static HPCCWsWorkUnitsClient client;
+    private static String  testwuid = System.getProperty("targetwuid");
 
-    @Override
-    @Before
+
+    @BeforeClass
     public void setup() throws Exception
     {
-        if (platform == null) super.setup();
-
-        if (client == null) client = wsclient.getWsWorkunitsClient();
-
+        client = wsclient.getWsWorkunitsClient();
         Assert.assertNotNull(client);
     }
 

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WUQueryTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WUQueryTest.java
@@ -9,22 +9,20 @@ import org.hpccsystems.ws.client.wrappers.ArrayOfEspExceptionWrapper;
 import org.hpccsystems.ws.client.wrappers.wsworkunits.WUQueryWrapper;
 import org.hpccsystems.ws.client.wrappers.wsworkunits.WUQueryWrapper.SortBy;
 import org.hpccsystems.ws.client.wrappers.wsworkunits.WorkunitWrapper;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(IntegrationTest.class)
 public class WUQueryTest extends BaseRemoteTest
 {
-    HPCCWsWorkUnitsClient wswuclient;
+    private static HPCCWsWorkUnitsClient wswuclient;
 
-    @Before
+    @BeforeClass
     public void setup() throws Exception
     {
-        super.setup();
-        wswuclient=wsclient.getWsWorkunitsClient();
+        wswuclient = wsclient.getWsWorkunitsClient();
     }
 
     @Test
@@ -117,11 +115,5 @@ public class WUQueryTest extends BaseRemoteTest
             Assert.fail("ascending state in wrong order:" + result.get(0).getState() + " then "
                     + result.get(result.size()-1).getState());
         }
-    }
-
-    @After
-    public void shutdown()
-    {
-        super.shutdown();
     }
 }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WsAttributesClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WsAttributesClientTest.java
@@ -23,26 +23,21 @@ import org.hpccsystems.ws.client.extended.HPCCWsAttributesClient;
 import org.hpccsystems.ws.client.platform.test.BaseRemoteTest;
 import org.hpccsystems.ws.client.utils.Connection;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class WsAttributesClientTest extends BaseRemoteTest
 {
 
-    HPCCWsAttributesClient client;
-    String testwuid = System.getProperty("targetwuid");
-    String port = System.getProperty("wsattributesport");
+    private static HPCCWsAttributesClient client = null;
+    private final static String testwuid = System.getProperty("targetwuid");
+    private final static String port = System.getProperty("8145");
 
-    @Before
+    @BeforeClass
     public void setup() throws Exception
     {
-        super.setup();
-
-        if (port == null || port.isEmpty())
-        {
+        if (System.getProperty("targetwuid") == null)
             System.out.println("No wsattributesport specified - defaulting to 8145");
-            port = "8145";
-        }
 
         Connection conn = new Connection(connection.getProtocol(), connection.getHost(), port);
         Assert.assertNotNull(conn);

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WsClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WsClientTest.java
@@ -2,15 +2,14 @@ package org.hpccsystems.ws.client;
 
 import org.hpccsystems.ws.client.platform.test.BaseRemoteTest;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 public class WsClientTest extends BaseRemoteTest
 {
-    String thortargetclustername = System.getProperty("thorgroupname");
-    String thorclustername = System.getProperty("thorclustername");
-    String roxietargetclustername = System.getProperty("roxiegroupname");
-    String roxieclustername = System.getProperty("roxieclustername");
+    private final static String thortargetclustername = System.getProperty("thorgroupname", "thor");
+    private final static String thorclustername = System.getProperty("thorclustername", "mythor");
+    private final static String roxietargetclustername = System.getProperty("roxiegroupname", "roxie");
+    private final static String roxieclustername = System.getProperty("roxieclustername", "myroxie");
 
     static
     {
@@ -25,21 +24,6 @@ public class WsClientTest extends BaseRemoteTest
 
         if (System.getProperty("roxieclustername") == null)
             System.out.println("roxieclustername not provided - defaulting to 'myroxie'");
-    }
-
-    @Before
-    public void setup() throws Exception
-    {
-        super.setup();
-
-        if (thortargetclustername == null)
-            thortargetclustername = "thor";
-        if (thorclustername == null)
-            thorclustername = "mythor";
-        if (roxietargetclustername == null)
-            roxietargetclustername = "roxie";
-        if (roxieclustername == null)
-            roxieclustername = "myroxie";
     }
 
     @Test

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WsDFUClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WsDFUClientTest.java
@@ -17,7 +17,6 @@ import org.hpccsystems.ws.client.wrappers.wsdfu.DFUInfoWrapper;
 import org.hpccsystems.ws.client.wrappers.wsdfu.DFULogicalFileWrapper;
 import org.hpccsystems.ws.client.wrappers.wsdfu.DFUResultWrapper;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.w3c.dom.NodeList;
@@ -25,15 +24,7 @@ import org.w3c.dom.NodeList;
 
 public class WsDFUClientTest extends BaseRemoteTest
 {
-    private HPCCWsDFUClient wsdfuclient = null;
-
-    @Before
-    public void setUp() throws Exception
-    {
-        wsdfuclient = wsclient.getWsDFUClient();
-
-        Assert.assertNotNull(wsdfuclient);
-    }
+    private final static HPCCWsDFUClient wsdfuclient = wsclient.getWsDFUClient();
 
     @Test
     public void testFileTypeWrapper()

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WsSMCClientTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WsSMCClientTest.java
@@ -7,21 +7,11 @@ import org.hpccsystems.ws.client.platform.Version;
 import org.hpccsystems.ws.client.platform.test.BaseRemoteTest;
 import org.hpccsystems.ws.client.utils.Connection;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 public class WsSMCClientTest extends BaseRemoteTest
 {
-    private HPCCWsSMCClient client = null;
-
-    @Before
-    public void setUp() throws Exception
-    {
-        super.setup();
-
-        client = wsclient.getWsSMCClient();
-        Assert.assertNotNull(client);
-    }
+    private static HPCCWsSMCClient client = wsclient.getWsSMCClient();
 
     @Test
     public void testFSPing()
@@ -62,8 +52,8 @@ public class WsSMCClientTest extends BaseRemoteTest
         Connection otherconnection = null;
         try
         {
-            otherconnection = new Connection(this.connection.getUrl());
-            if (this.hpccUser == null && this.hpccUser.isEmpty())
+            otherconnection = new Connection(connection.getUrl());
+            if (hpccUser == null && hpccUser.isEmpty())
             {
                 otherconnection.setUserName("something"); //ensuring this connection is different
             }

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/WsWorkunitsClientIntegrationTest_620.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/WsWorkunitsClientIntegrationTest_620.java
@@ -8,8 +8,8 @@ public class WsWorkunitsClientIntegrationTest_620 extends BaseWsWorkunitsClientI
     @Override
     protected void confirmPlatform() throws Exception
     {
-        if (super.platform.getVersion().toString().startsWith(hpccver))
-            throw new Exception("Cannot run 6.2 tests against HPCC cluster on '" + super.platform.getIP() + "' version: '" + super.platform.getVersion().toString() + "'");
+        if (platform.getVersion().toString().startsWith(hpccver))
+            throw new Exception("Cannot run 6.2 tests against HPCC cluster on '" + platform.getIP() + "' version: '" + platform.getVersion().toString() + "'");
     }
 
     @Override

--- a/wsclient/src/test/java/org/hpccsystems/ws/client/platform/EclParseRegressionTest.java
+++ b/wsclient/src/test/java/org/hpccsystems/ws/client/platform/EclParseRegressionTest.java
@@ -46,7 +46,6 @@ public class EclParseRegressionTest extends BaseRemoteTest
     @Before
     public void setup() throws Exception
     {
-        super.setup();
         if (targetThorName == null)
         {
             System.out.println("EclParseRegressionTest: No 'thorname' system prop provided, defaulting to 'thor' cluster name");
@@ -63,7 +62,6 @@ public class EclParseRegressionTest extends BaseRemoteTest
             targetHthorName = "roxie";
         }
     }
-
 
     File failedlist=new File("failedrecs.txt");
     File testlist=new File("alreadytested.txt");


### PR DESCRIPTION
- Ensure baseremotetest fields initialized in static block
- No longer re-initialize final static fields in setup method
- FileFilter was swallowing exceptions
- DFSClient's hpccfile was not setting targetfilecluster

Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [x] I have created a corresponding JIRA ticket for this submission
- [x] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [ ] The change has been fully tested:
  - [ ] I have performed unit tests to cover my changes.
  - [ ] I have performed system test and covered possible regressions and side effects.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
