### PR TITLE
JAPI-293 Address WsSQL fulltest junit error

### DIFF
--- a/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsSQLClient.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/HPCCWsSQLClient.java
@@ -487,7 +487,7 @@ public class HPCCWsSQLClient extends BaseHPCCWsClient
     {
         return executeSQLWUResponse(
                 sqlText, targetCluster, targetQuerySet, DEFAULT_RESULT_LIMIT, null /* resultWindowCount */, null /* resultWindowStart */,
-                null /* suppressResults */, true /* Boolean suppressXmlSchema */, null /* String userName */, null /* Integer wait */).getWuid();
+                true /* suppressResults */, true /* Boolean suppressXmlSchema */, null /* String userName */, null /* Integer wait */).getWuid();
     }
 
     /**
@@ -535,7 +535,7 @@ public class HPCCWsSQLClient extends BaseHPCCWsClient
 
         request.setSqlText(sqlText);
 
-        if (resultWindowStart != null) request.setSuppressResults(suppressResults);
+        if (suppressResults != null) request.setSuppressResults(suppressResults);
         if (suppressXmlSchema != null) request.setSuppressXmlSchema(suppressXmlSchema);
 
         request.setTargetCluster(targetCluster);
@@ -610,8 +610,8 @@ public class HPCCWsSQLClient extends BaseHPCCWsClient
             throws Exception, ArrayOfEspExceptionWrapper, ArrayOfECLExceptionWrapper
     {
         return executeSQLFullResponse(
-                sqlText, targetCluster, targetQuerySet, DEFAULT_RESULT_LIMIT, null /* resultWindowCount */, null /* resultWindowStart */,
-                null /* suppressResults */, true /* Boolean suppressXmlSchema */, null /* String userName */, null /* Integer wait */).getWorkunit();
+                sqlText, targetCluster, targetQuerySet, DEFAULT_RESULT_LIMIT, resultWindowCount /* resultWindowCount */, resultWindowStart /* resultWindowStart */,
+                suppressResults /* suppressResults */, suppressXmlSchema /* Boolean suppressXmlSchema */, userName /* String userName */, wait /* Integer wait */).getWorkunit();
     }
 
     /**
@@ -715,7 +715,7 @@ public class HPCCWsSQLClient extends BaseHPCCWsClient
      */
     public String getResultSchemaXML(String wuid) throws Exception, ArrayOfEspExceptionWrapper, ArrayOfECLExceptionWrapper
     {
-        return Utils.extactResultSchema("<root>" + getResultResponse(wuid, 0, 0, false).getResult() + "</root>");
+        return Utils.extactResultSchema("<root>" + getResultResponse(wuid, 0, 1, false).getResult() + "</root>");
     }
 
     /**
@@ -733,7 +733,7 @@ public class HPCCWsSQLClient extends BaseHPCCWsClient
      */
     public List<List<Object>> getResultSchema(String wuid) throws Exception, ArrayOfEspExceptionWrapper, ArrayOfECLExceptionWrapper
     {
-        return Utils.parseOutResultSchema("<root>" + getResultResponse(wuid, 0, 0, false).getResult() + "</root>");
+        return Utils.parseOutResultSchema("<root>" + getResultResponse(wuid, 0, 1, false).getResult() + "</root>");
     }
 
     /**


### PR DESCRIPTION
- Exercise all executeSQL methods
- Method returning wuid should suppress results
- Decrease response sizes
- Various refactors


Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [x] I have created a corresponding JIRA ticket for this submission
- [x] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [x] The change has been fully tested:
  - [ ] I have performed unit tests to cover my changes.
  - [ ] I have performed system test and covered possible regressions and side effects.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
