### PR TITLE
JAPI-318 : provide way to define connect timeout when writing files.

### DIFF
--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/HPCCRemoteFileWriter.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/HPCCRemoteFileWriter.java
@@ -51,6 +51,28 @@ public class HPCCRemoteFileWriter<T>
     public HPCCRemoteFileWriter(DataPartition dp, FieldDef recordDef, IRecordAccessor recordAccessor, CompressionAlgorithm fileCompression)
             throws Exception
     {
+        this(dp,recordDef,recordAccessor,fileCompression,RowServiceOutputStream.DEFAULT_CONNECT_TIMEOUT_MILIS);
+    }
+
+    /**
+     * A remote file writer.
+     *
+     * @param dp
+     *            the part of the file, name and location
+     * @param recordDef
+     *            the record def
+     * @param recordAccessor
+     *            the record accessor
+     * @param fileCompression
+     *            the file compression
+     * @param connectTimeoutMs
+     *            the socket timeout in ms (default is 1000)
+     * @throws Exception
+     *             the exception
+     */
+    public HPCCRemoteFileWriter(DataPartition dp, FieldDef recordDef, IRecordAccessor recordAccessor, CompressionAlgorithm fileCompression, int connectTimeoutMs)
+            throws Exception
+    {
         this.recordDef = recordDef;
         this.dataPartition = dp;
 
@@ -58,7 +80,7 @@ public class HPCCRemoteFileWriter<T>
 
         this.outputStream = new RowServiceOutputStream(dataPartition.getCopyIP(0), dataPartition.getPort(), dataPartition.getUseSsl(),
                 dataPartition.getFileAccessBlob(), this.recordDef, this.dataPartition.getThisPart(), this.dataPartition.getCopyPath(0),
-                fileCompression);
+                fileCompression, connectTimeoutMs);
 
         this.binaryRecordWriter = new BinaryRecordWriter(this.outputStream);
         this.binaryRecordWriter.initialize(this.recordAccessor);

--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/RowServiceOutputStream.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/RowServiceOutputStream.java
@@ -32,7 +32,7 @@ import org.hpccsystems.commons.ecl.FieldDef;
 public class RowServiceOutputStream extends OutputStream
 {
     private static final Logger  log                           = LogManager.getLogger(RowServiceOutputStream.class);
-    private static int           DEFAULT_CONNECT_TIMEOUT_MILIS = 1000;                                              // 1 second connection timeout
+    public static final int           DEFAULT_CONNECT_TIMEOUT_MILIS = 1000;                                              // 1 second connection timeout
     private static int           SCRATCH_BUFFER_LEN            = 2048;
 
     private String               rowServiceIP                  = null;
@@ -102,6 +102,37 @@ public class RowServiceOutputStream extends OutputStream
     RowServiceOutputStream(String ip, int port, boolean useSSL, String accessToken, FieldDef recordDef, int filePartIndex, String filePartPath,
             CompressionAlgorithm fileCompression) throws Exception
     {
+        this(ip,port,useSSL,accessToken,recordDef,filePartIndex,filePartPath,fileCompression, DEFAULT_CONNECT_TIMEOUT_MILIS);
+    }
+
+
+    /**
+     * Creates RowServiceOutputStream to be used to stream data to target dafilesrv on HPCC cluster.
+     *
+     * @param ip
+     *            the ip
+     * @param port
+     *            the port
+     * @param useSSL
+     *            the use SSL
+     * @param accessToken
+     *            the access token
+     * @param recordDef
+     *            the record def
+     * @param filePartIndex
+     *            the file part index
+     * @param filePartPath
+     *            the file part path
+     * @param fileCompression
+     *            the file compression
+     * @param connectTimeoutMs
+     *            the socket timeout in ms (default is 1000)
+     * @throws Exception
+     *             the exception
+     */
+    RowServiceOutputStream(String ip, int port, boolean useSSL, String accessToken, FieldDef recordDef, int filePartIndex, String filePartPath,
+            CompressionAlgorithm fileCompression, int connectTimeoutMs) throws Exception
+    {
         this.rowServiceIP = ip;
         this.rowServicePort = port;
         this.recordDef = recordDef;
@@ -121,7 +152,7 @@ public class RowServiceOutputStream extends OutputStream
                 // We are opening up a long standing connection and writing a significant amount of data
                 // So we don't care as much about individual packet latency or connection time overhead
                 socket.setPerformancePreferences(0, 1, 2);
-                socket.connect(new InetSocketAddress(this.rowServiceIP, this.rowServicePort), DEFAULT_CONNECT_TIMEOUT_MILIS);
+                socket.connect(new InetSocketAddress(this.rowServiceIP, this.rowServicePort), connectTimeoutMs);
 
                 log.debug("Attempting SSL handshake...");
                 ((SSLSocket) this.socket).startHandshake();

--- a/wsclient/src/main/java/org/hpccsystems/ws/client/platform/test/BaseRemoteTest.java
+++ b/wsclient/src/main/java/org/hpccsystems/ws/client/platform/test/BaseRemoteTest.java
@@ -42,7 +42,7 @@ public abstract class BaseRemoteTest
 
     protected final static String hpccUser = System.getProperty("hpccuser", defaultUserName);
     protected final static String hpccPass = System.getProperty("hpccpass", "");
-    protected final static String connTO = System.getProperty("connecttimeoutmillis");
+    protected final static Integer connTO = System.getProperty("connecttimeoutmillis")==null?null:Integer.valueOf(System.getProperty("connecttimeoutmillis"));
     protected final static String sockTO = System.getProperty("sockettimeoutmillis");
 
     /*
@@ -151,7 +151,7 @@ public abstract class BaseRemoteTest
             connection.setCredentials(hpccUser, hpccPass);
 
             if (connTO != null)
-            	connection.setConnectTimeoutMilli(Integer.valueOf(connTO));
+            	connection.setConnectTimeoutMilli(connTO);
 
             if (sockTO != null)
             	connection.setSocketTimeoutMilli(Integer.valueOf(sockTO));


### PR DESCRIPTION
* Create additional constructor for HPCCRemoteFileWriter that takes a connect timeout value
* update current constructor for HPCCRemoteFileWriter to call the new constructor, passing RowServiceOutputWriter.DEFAULT_CONNECT_TIMEOUT_MILLIS
* Create additional constructor for RowServiceOutputWriter that takes a connect timeout value
* update current (non-deprecated) constructor for RowServiceOutputWriter to call the new constructor, passing RowServiceOutputWriter.DEFAULT_CONNECT_TIMEOUT_MILLIS
* update DFSReadWriteTest so that it can run passing a connect timeout value defined as a system property. If no connect timeout is defined, the test runs as it used do with default timeouts specified.

<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [X] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
  - [] I have applied the Eclipse code-format template provided.
- [X] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [X] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [X] The change has been fully tested:
  - [X] I have performed unit tests to cover my changes.
  - [X] I have performed system test and covered possible regressions and side effects.
  - [X] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested the change by running DFUReadWriteTest with and without the connecttimeoutms system property specified.

 Also, compiled the jar with changes and tested it from the tardis hpcc module. Confirmed that these changes resolved the issues tardis was experiencing with write connection timeouts.
