### PR TITLE
JAPI-325 BinaryRecordReader not correctly handle integer overflow for non-standard types

### DIFF
--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/BinaryRecordReader.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/BinaryRecordReader.java
@@ -639,7 +639,7 @@ public class BinaryRecordReader implements IRecordReader
         long v = getUnsigned(len, little_endian);
 
         // Make the value negative if it should have been by extending sign bit
-        long negMask = (0x80 << (len - 1) * 8);
+        long negMask = (0x80L << (len - 1) * 8);
         if ((v & negMask) != 0)
         {
             for (int i = len; i < 8; i++)

--- a/dfsclient/src/main/java/org/hpccsystems/dfs/client/BinaryRecordWriter.java
+++ b/dfsclient/src/main/java/org/hpccsystems/dfs/client/BinaryRecordWriter.java
@@ -331,10 +331,22 @@ public class BinaryRecordWriter implements IRecordWriter
                 {
                     this.buffer.putLong(value);
                 }
+                else if (fd.getDataLen() < 8 && fd.getDataLen() > 0)
+                {
+                    long lastByteIdx = fd.getDataLen() -1;
+                    for (int i = 0; i < lastByteIdx; i++)
+                    {
+                        this.buffer.put((byte) ((value >> (i*8)) & 0xFF));
+                    }
+                   
+                    long signBit = value < 0 ? 0x80L : 0;
+                    this.buffer.put((byte) (((value >> (lastByteIdx*8)) & 0xFF) | signBit));
+                }
                 else
                 {
                     throw new Exception("Unsupported integer length: " + fd.getDataLen() + " for field: " + fd.getFieldName());
                 }
+
                 break;
             }
             case DECIMAL:

--- a/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
+++ b/dfsclient/src/test/java/org/hpccsystems/dfs/client/DFSReadWriteTest.java
@@ -255,16 +255,24 @@ public class DFSReadWriteTest extends BaseRemoteTest
     public void numericOverflowTest() throws Exception
     {
         // Create a large record dataset
-        FieldDef[] fieldDefs = new FieldDef[7];
+        FieldDef[] fieldDefs = new FieldDef[15];
         fieldDefs[0] = new FieldDef("int1", FieldType.INTEGER, "INTEGER1", 1, true, false, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
         fieldDefs[1] = new FieldDef("uint1", FieldType.INTEGER, "UNSIGNED1", 1, true, true, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
         fieldDefs[2] = new FieldDef("int2", FieldType.INTEGER, "INTEGER2", 2, true, false, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
         fieldDefs[3] = new FieldDef("uint2", FieldType.INTEGER, "UNSIGNED2", 2, true, true, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
-        fieldDefs[4] = new FieldDef("int4", FieldType.INTEGER, "INTEGER4", 4, true, false, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
-        fieldDefs[5] = new FieldDef("uint4", FieldType.INTEGER, "UNSIGNED4", 4, true, true, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
-        fieldDefs[6] = new FieldDef("dec24", FieldType.DECIMAL, "DECIMAL24_12", 0, true, false, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
-        fieldDefs[6].setPrecision(24);
-        fieldDefs[6].setScale(12);
+        fieldDefs[4] = new FieldDef("int3", FieldType.INTEGER, "INTEGER3", 3, true, false, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
+        fieldDefs[5] = new FieldDef("uint3", FieldType.INTEGER, "UNSIGNED3", 3, true, true, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
+        fieldDefs[6] = new FieldDef("int4", FieldType.INTEGER, "INTEGER4", 4, true, false, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
+        fieldDefs[7] = new FieldDef("uint4", FieldType.INTEGER, "UNSIGNED4", 4, true, true, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
+        fieldDefs[8] = new FieldDef("int5", FieldType.INTEGER, "INTEGER5", 5, true, false, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
+        fieldDefs[9] = new FieldDef("uint5", FieldType.INTEGER, "UNSIGNED5", 5, true, true, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
+        fieldDefs[10] = new FieldDef("int6", FieldType.INTEGER, "INTEGER6", 6, true, false, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
+        fieldDefs[11] = new FieldDef("uint6", FieldType.INTEGER, "UNSIGNED6", 6, true, true, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
+        fieldDefs[12] = new FieldDef("int7", FieldType.INTEGER, "INTEGER7", 7, true, false, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
+        fieldDefs[13] = new FieldDef("uint7", FieldType.INTEGER, "UNSIGNED7", 7, true, true, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
+        fieldDefs[14] = new FieldDef("dec24", FieldType.DECIMAL, "DECIMAL24_12", 0, true, false, HpccSrcType.LITTLE_ENDIAN, new FieldDef[0]);
+        fieldDefs[14].setPrecision(24);
+        fieldDefs[14].setScale(12);
 
         FieldDef recordDef = new FieldDef("RootRecord", FieldType.RECORD, "rec", 4, false, false, HpccSrcType.LITTLE_ENDIAN, fieldDefs);
         
@@ -272,14 +280,36 @@ public class DFSReadWriteTest extends BaseRemoteTest
         List<HPCCRecord> records = new ArrayList<HPCCRecord>();
         for (int i = 0; i < 10; i++)
         {
-            Object[] fields = new Object[7];
+            Object[] fields = new Object[15];
+            // 1 Byte ints
             fields[0] = new Long(128);
             fields[1] = new Long(256);
+            
+            // 2 Byte ints
             fields[2] = new Long(32768);
             fields[3] = new Long(65536);
-            fields[4] = new Long(2147483648L);
-            fields[5] = new Long(4294967296L);
-            fields[6] = new BigDecimal(intDigits,0);
+            
+            // 3 Byte ints
+            fields[4] = new Long(8388608);
+            fields[5] = new Long(16777216);
+            
+            // 4 Byte ints
+            fields[6] = new Long(2147483648L);
+            fields[7] = new Long(4294967296L);
+            
+            // 5 Byte ints
+            fields[8] = new Long(549755813888L);
+            fields[9] = new Long(1099511627776L);
+            
+            // 6 Byte ints
+            fields[10] = new Long(140737488355328L);
+            fields[11] = new Long(281474976710656L);
+
+            // 7 Byte ints
+            fields[12] = new Long(36028797018963968L);
+            fields[13] = new Long(72057594037927936L);
+
+            fields[14] = new BigDecimal(intDigits,0);
             HPCCRecord record = new HPCCRecord(fields, recordDef);
             records.add(record);
         }
@@ -289,24 +319,38 @@ public class DFSReadWriteTest extends BaseRemoteTest
 
         HPCCFile file = new HPCCFile(fileName, connString , hpccUser, hpccPass);
 
-        Object[] expectedFields = new Object[7];
+        Object[] expectedFields = new Object[15];
         expectedFields[0] = new Long(-128);
         expectedFields[1] = new Long(0);
+        
         expectedFields[2] = new Long(-32768);
         expectedFields[3] = new Long(0);
-        expectedFields[4] = new Long(-2147483648L);
+       
+        expectedFields[4] = new Long(-8388608);
         expectedFields[5] = new Long(0);
 
+        expectedFields[6] = new Long(-2147483648L);
+        expectedFields[7] = new Long(0);
+
+        expectedFields[8] = new Long(-549755813888L);
+        expectedFields[9] = new Long(0);
+        
+        expectedFields[10] = new Long(-140737488355328L);
+        expectedFields[11] = new Long(0);
+
+        expectedFields[12] = new Long(-36028797018963968L);
+        expectedFields[13] = new Long(0);
+
         BigDecimal expectedDecimal = new BigDecimal(BigInteger.valueOf(567890000000L),0);
-        expectedFields[6] = expectedDecimal.setScale(12);
+        expectedFields[14] = expectedDecimal.setScale(12);
 
         HPCCRecord expectedRecord = new HPCCRecord(expectedFields, recordDef);
         records = readFile(file, connTO);
         for (int i = 0; i < 10; i++)
         {
             HPCCRecord record = records.get(i);
-            BigDecimal actDecimal = (BigDecimal) record.getField(6);
-            record.setField(6,actDecimal.setScale(12));
+            BigDecimal actDecimal = (BigDecimal) record.getField(14);
+            record.setField(14,actDecimal.setScale(12));
 
             if (record.equals(expectedRecord) == false)
             {


### PR DESCRIPTION

- Corrected bug in sign extension code
- Added support for writing int3,int5,int6,int7
- Updated numeric overflow tests for non standard int sizes

Signed-off-by: James McMullan <James.McMullan@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC Java APIs (JAPIS) project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues (https://track.hpccsystems.com/).
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 JAPI-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,and
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and check-off all the items that apply (after pull request has been created)
-->

## Type of change:
- [X] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).

## Checklist:
- [X] I have created a corresponding JIRA ticket for this submission
- [X] My code follows the code style of this project.
  - [ ] I have applied the Eclipse code-format template provided.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the HPCC Systems CONTRIBUTORS document (https://github.com/hpcc-systems/HPCC-Platform/wiki/Guide-for-contributors).
- [X] The change has been fully tested:
  - [X] I have performed unit tests to cover my changes.
  - [ ] I have performed system test and covered possible regressions and side effects.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
